### PR TITLE
도서관마다 총 책권수를 파싱하는 프로세서 구현

### DIFF
--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/entity/Library.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/entity/Library.java
@@ -29,11 +29,18 @@ public class Library {
     @Embedded
     LibraryUrl libraryUrl;
 
+    int totalBookCount;
+
     @Builder
-    public Library(String name, LibraryType type, String libraryUrl) {
+    public Library(String name, LibraryType type, String libraryUrl, int totalBookCount) {
         this.name = name;
         this.type = type;
         this.libraryUrl = new LibraryUrl(libraryUrl);
+        this.totalBookCount = totalBookCount;
+    }
+
+    public void updateTotalBookCount(int totalBookCount) {
+        this.totalBookCount = totalBookCount;
     }
 
     public boolean hasMainInk() {

--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/entity/LibraryUrl.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/entity/LibraryUrl.java
@@ -26,7 +26,7 @@ public class LibraryUrl {
     private String url;
 
     public String getUrlWithQueryParameters(int viewCnt) {
-        return getBaseUrl() + getPort() + getELibraryFront() + CONTENT_LIST + getQueryParameters(
+        return getBaseUrl() + getELibraryFront() + CONTENT_LIST + getQueryParameters(
             viewCnt);
     }
 

--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/service/LibraryService.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/service/LibraryService.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -43,5 +44,11 @@ public class LibraryService {
 
     public List<Library> findAll() {
         return libraryRepository.findAll();
+    }
+
+    @Transactional
+    public void updateTotalBookCount(int totalBookCount, String baseUrl) {
+        Library library = findByBaseUrl(baseUrl);
+        library.updateTotalBookCount(totalBookCount);
     }
 }

--- a/be/ebook-search/ebook-core/src/test/java/LibraryTest.java
+++ b/be/ebook-search/ebook-core/src/test/java/LibraryTest.java
@@ -1,0 +1,24 @@
+import com.meetyourbook.entity.Library;
+import com.meetyourbook.entity.Library.LibraryType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class LibraryTest {
+
+    @Test
+    @DisplayName("파싱을 위한 최종 url 생성에 문제가 없는지 테스트")
+    void testUrlCreation() {
+        Library library = Library.builder()
+            .name("example")
+            .type(LibraryType.UNIVERSITY_LIBRARY)
+            .libraryUrl("https://ebook.howon.ac.kr:444/elibrary-front/main.ink")
+            .totalBookCount(0)
+            .build();
+
+        String url = library.getUrlWithQueryParameters(1);
+        Assertions.assertThat(url).isEqualTo("https://ebook.howon.ac.kr:444/elibrary-front/content/contentList.ink?brcd=&sntnAuthCode=&contentAll=Y&cttsDvsnCode=001&ctgrId=&orderByKey=publDate&selViewCnt=1&pageIndex=1&recordCount=20");
+    }
+
+
+}

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/crawler/BookCountProcessor.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/crawler/BookCountProcessor.java
@@ -1,0 +1,64 @@
+package com.meetyourbook.crawler;
+
+import com.meetyourbook.entity.LibraryUrl;
+import com.meetyourbook.service.LibraryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+import us.codecraft.webmagic.Page;
+import us.codecraft.webmagic.Site;
+import us.codecraft.webmagic.processor.PageProcessor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookCountProcessor implements PageProcessor {
+
+    private static final String BOOK_RESULT_TXT_CLASS = "book_resultTxt";
+    private static final String STRONG_TAG = "strong";
+
+    private final Site site = Site.me().setTimeOut(10000000).setSleepTime(8000).setCycleRetryTimes(3).setRetryTimes(3);
+
+    private final LibraryService libraryService;
+
+    @Override
+    public Site getSite() {
+        return site;
+    }
+
+    @Override
+    public void process(Page page) {
+        String baseUrl = new LibraryUrl(page.getUrl().get()).getBaseUrl();
+        Document doc = page.getHtml().getDocument();
+
+        int totalBookCount = getTotalBookCount(doc);
+        log.info("도서관 URL: {}, 책의 총 개수: {}", baseUrl, totalBookCount);
+
+        libraryService.updateTotalBookCount(totalBookCount, baseUrl);
+
+    }
+
+    private int getTotalBookCount(Document document) {
+        Element bookResultTxt = document.getElementsByClass(BOOK_RESULT_TXT_CLASS).first();
+        if (bookResultTxt == null) {
+            log.warn("BookResultText가 존재하지 않습니다.");
+            return 0;
+        }
+
+        Element strongElement = bookResultTxt.getElementsByTag(STRONG_TAG).first();
+        if (strongElement == null) {
+            log.warn("BookResultText에서 Strong태그 Element가 없음");
+            return 0;
+        }
+
+        String countText = strongElement.text().replaceAll("\\D", "");
+        try {
+            return Integer.parseInt(countText);
+        } catch (NumberFormatException e) {
+            log.error("책의 총개수를 파싱하는 과정에서 오류가 생김", e);
+            return 0;
+        }
+    }
+}

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/crawler/BookPageProcessor.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/crawler/BookPageProcessor.java
@@ -34,8 +34,6 @@ public class BookPageProcessor implements PageProcessor {
     private static final String SRC_ATTR = "src";
     private static final String SPAN_TAG = "span";
     private static final String I_TAG = "i";
-    private static final String BOOK_RESULT_TXT_CLASS = "book_resultTxt";
-    private static final String STRONG_TAG = "strong";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
 
     private final Site site = Site.me().setTimeOut(10000000).setSleepTime(8000);
@@ -57,8 +55,6 @@ public class BookPageProcessor implements PageProcessor {
         log.info("사이트 이름: {}", baseUrl);
 
         Document doc = page.getHtml().getDocument();
-        int totalBookCount = getTotalBookCount(doc);
-        log.info("총 책의 수: {}", totalBookCount);
 
         List<BookInfo> bookInfos = parseBooks(doc);
         log.info("파싱된 책의 개수: {}", bookInfos.size());
@@ -126,28 +122,6 @@ public class BookPageProcessor implements PageProcessor {
         } catch (Exception e) {
             log.error("Error parsing book info", e);
             return Optional.empty();
-        }
-    }
-
-    private int getTotalBookCount(Document document) {
-        Element bookResultTxt = document.getElementsByClass(BOOK_RESULT_TXT_CLASS).first();
-        if (bookResultTxt == null) {
-            log.warn("BookResultText가 존재하지 않습니다.");
-            return 0;
-        }
-
-        Element strongElement = bookResultTxt.getElementsByTag(STRONG_TAG).first();
-        if (strongElement == null) {
-            log.warn("BookResultText에서 Strong태그 Element가 없음");
-            return 0;
-        }
-
-        String countText = strongElement.text().replaceAll("\\D", "");
-        try {
-            return Integer.parseInt(countText);
-        } catch (NumberFormatException e) {
-            log.error("책의 총개수를 파싱하는 과정에서 오류가 생김", e);
-            return 0;
         }
     }
 

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/crawler/ProcessorFactory.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/crawler/ProcessorFactory.java
@@ -1,0 +1,31 @@
+package com.meetyourbook.crawler;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import us.codecraft.webmagic.processor.PageProcessor;
+
+@Component
+public class ProcessorFactory {
+
+    private final Map<String, PageProcessor> processors;
+
+    public ProcessorFactory(List<PageProcessor> processorList) {
+        processors = processorList.stream()
+            .collect(Collectors.toMap(
+                processor -> processor.getClass().getSimpleName(),
+                Function.identity()
+            ));
+    }
+
+    public PageProcessor getProcessor(String processorName) {
+        PageProcessor pageProcessor = processors.get(processorName);
+        if (pageProcessor == null) {
+            throw new IllegalArgumentException("잘못된 크롤링 프로세서 이름입니다: " + processorName);
+        }
+        return pageProcessor;
+    }
+
+}


### PR DESCRIPTION
## 변경 사항
- 도서관마다 총 책권수를 파싱하는 프로세서를 구현
- 크롤링에 필요한 프로세서를 환경변수 값으로 정할 수 있습니다.
- 원하는 processor는 환경변수에 프로세서 클래스 이름을 적으면 됩니다.

## 관련 이슈
x

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [x] 버그 수정
- [x] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)
<img width="537" alt="image" src="https://github.com/user-attachments/assets/6ac1629f-d3f3-4730-a466-865edc0d0a44">

## 추가 설명
x