### PR TITLE
크롤러를 시작하고 멈추는 api 구현

### DIFF
--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/BookCrawlerController.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/BookCrawlerController.java
@@ -1,0 +1,31 @@
+package com.meetyourbook.controller;
+
+import com.meetyourbook.dto.CrawlerRequest;
+import com.meetyourbook.service.BookCrawlerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/crawler")
+@RequiredArgsConstructor
+public class BookCrawlerController {
+
+    private final BookCrawlerService bookCrawlerService;
+
+    @PostMapping("/start")
+    public ResponseEntity<String> startCrawler(@RequestBody CrawlerRequest request) {
+        String crawlerId = bookCrawlerService.startCrawl(request.processor(), request.maxUrl(), request.viewCount());
+        return ResponseEntity.ok("크롤러가 시작되었습니다. ID: " + crawlerId);
+    }
+
+    @GetMapping("/stop")
+    public ResponseEntity<String> stopCrawler() {
+        bookCrawlerService.stopCrawl();
+        return ResponseEntity.ok("크롤러가 멈췄습니다.");
+    }
+}

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/crawler/BookPageProcessor.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/crawler/BookPageProcessor.java
@@ -1,5 +1,7 @@
 package com.meetyourbook.crawler;
 
+import static com.meetyourbook.service.BookCrawlerService.pageQueue;
+
 import com.meetyourbook.dto.BookInfo;
 import com.meetyourbook.entity.LibraryUrl;
 import com.meetyourbook.service.BookQueueService;
@@ -10,11 +12,12 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import us.codecraft.webmagic.Page;
 import us.codecraft.webmagic.Site;
@@ -22,7 +25,6 @@ import us.codecraft.webmagic.processor.PageProcessor;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class BookPageProcessor implements PageProcessor {
 
     private static final String RESULT_LIST_CLASS = "book_resultList";
@@ -43,6 +45,14 @@ public class BookPageProcessor implements PageProcessor {
 
     private String baseUrl;
 
+    @Autowired
+    public BookPageProcessor(BookQueueService bookQueueService,
+        @Qualifier("pagesCounter") Counter pagesCounter,
+        @Qualifier("booksCounter") Counter booksCounter) {
+        this.bookQueueService = bookQueueService;
+        this.pagesCounter = pagesCounter;
+        this.booksCounter = booksCounter;
+    }
 
     @Override
     public Site getSite() {
@@ -66,7 +76,7 @@ public class BookPageProcessor implements PageProcessor {
 
             try {
                 String nextUrl = fetchNextUrl(page.getUrl().get());
-                BookCrawlerRunner.pageQueue.add(nextUrl);
+                pageQueue.add(nextUrl);
             } catch (URISyntaxException e) {
                 log.error("다음 페이지 URL을 가져오는 과정에서 오류가 생김", e);
             }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/dto/CrawlerRequest.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/dto/CrawlerRequest.java
@@ -1,0 +1,5 @@
+package com.meetyourbook.dto;
+
+public record CrawlerRequest(String processor, int maxUrl, int viewCount) {
+
+}

--- a/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/service/BookCrawlerServiceTest.java
+++ b/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/service/BookCrawlerServiceTest.java
@@ -1,0 +1,93 @@
+package com.meetyourbook.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import com.meetyourbook.crawler.ProcessorFactory;
+import com.meetyourbook.entity.Library;
+import com.meetyourbook.entity.Library.LibraryType;
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import us.codecraft.webmagic.processor.PageProcessor;
+
+class BookCrawlerServiceTest {
+
+    @Mock
+    private ProcessorFactory processorFactory;
+    @Mock
+    private LibraryService libraryService;
+    @Mock
+    private DataSource dataSource;
+    @Mock
+    private MeterRegistry meterRegistry;
+    @Mock
+    private PageProcessor pageProcessor;
+    @Mock
+    private HikariDataSource hikariDataSource;
+    @Mock
+    private HikariPoolMXBean hikariPoolMXBean;
+
+    private BookCrawlerService bookCrawlerService;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        MockitoAnnotations.openMocks(this);
+        when(dataSource.unwrap(HikariDataSource.class)).thenReturn(hikariDataSource);
+        when(hikariDataSource.getHikariPoolMXBean()).thenReturn(hikariPoolMXBean);
+        when(processorFactory.getProcessor(anyString())).thenReturn(pageProcessor);
+
+        bookCrawlerService = new BookCrawlerService(processorFactory, libraryService, dataSource,
+            meterRegistry);
+    }
+
+    @Test
+    @DisplayName("크롤러의 생명 주기 테스트")
+    void testCrawlerLifeCycle() throws InterruptedException {
+
+        // 도서관 데이터 준비
+        Library ASMLLibrary = Library.builder()
+            .name("ASML")
+            .type(LibraryType.UNIVERSITY_LIBRARY)
+            .libraryUrl("https://asml.dkyobobook.co.kr/main.ink")
+            .build();
+
+        Library NCLibrary = Library.builder()
+            .name("NC")
+            .type(LibraryType.UNIVERSITY_LIBRARY)
+            .libraryUrl("https://ncsoft.dkyobobook.co.kr/main.ink")
+            .build();
+
+        when(libraryService.findAll()).thenReturn(List.of(ASMLLibrary, NCLibrary));
+
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicInteger count = new AtomicInteger(0);
+
+        doAnswer(invocation -> {
+            count.incrementAndGet();
+            latch.countDown();
+            return null;
+        }).when(pageProcessor).process(any());
+
+        //크롤링 시작
+        String crawlerId = bookCrawlerService.startCrawl("BookPageProcessor", 50, 20);
+        assertNotEquals("Crawler is already running", crawlerId);
+
+        assertEquals(2, latch.getCount());
+
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 크롤러를 시작하고 멈출 수 있는 api를 구현
- 크롤러 생명주기 테스트 코드 추가

## 관련 이슈
#5 

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [x] 버그 수정
- [x] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)
크롤링을 시작할 때
<img width="1375" alt="image" src="https://github.com/user-attachments/assets/de5e5918-ea2f-4aa9-911c-42cd34977799">

크롤링 중단 요청을 보낸 후
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/57e95129-c8c8-4deb-a402-0a76659760a1">


## 추가 설명
- 크롤링 생명주기 테스트코드를 추가했고 크롤링 동작(유닛 테스트)은 잘 이루어지지만 테스트가 굉장히 빨리 끝나는 문제가 존재함. 크롤링의 유닛테스트와 통합테스트 그리고 테스트용 데이터를 어떻게 할지 더 많은 고민이 필요하다고 생각됩니다.