### PR TITLE
[BE] 책 상세 페이지 URL을 파싱하고 저장하는 기능

### DIFF
--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/service/BookLibraryService.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/service/BookLibraryService.java
@@ -34,7 +34,8 @@ public class BookLibraryService {
         for (BookInfo bookInfo : bookInfos) {
             Book book = getBook(bookInfo);
             Library library = getLibrary(bookInfo);
-            BookLibrary bookLibrary = BookLibrary.createBookLibrary(book, library, bookInfo.getBookUrl());
+            BookLibrary bookLibrary = BookLibrary.createBookLibrary(book, library,
+                bookInfo.getBookUrl());
             bookLibraries.add(bookLibrary);
         }
         bookLibraryRepository.saveAll(bookLibraries);

--- a/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/crawler/BookPageProcessorTest.java
+++ b/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/crawler/BookPageProcessorTest.java
@@ -28,7 +28,7 @@ import us.codecraft.webmagic.selector.Html;
 import us.codecraft.webmagic.selector.PlainText;
 
 @ExtendWith(MockitoExtension.class)
-public class BookPageProcessorTest {
+class BookPageProcessorTest {
 
     @Mock
     private BookQueueService bookQueueService;
@@ -56,19 +56,32 @@ public class BookPageProcessorTest {
     void parseBookInfo_ShouldAddToQueue() {
         // given
         String htmlContent = """
-            <div class="book_resultList">
-                <div>
-                    <div class="store">TestStore</div>
-                    <div class="tit">테스트 책 제목</div>
-                    <div class="writer">
-                        제이든
-                        <span>테스트 출판사</span>
-                        2024-01-01
-                    </div>
-                    <img src="//example.com/book-cover.jpg" />
-                </div>
-            </div>
+                <ul class="book_resultList">
+                    <li>
+                        <div class="img">
+                            <a href="/content/contentView.ink" title="테스트 책 제목 | ASML 전자도서관" class="scale" onclick="javascript:contentList.fnContentClick(this, '001', 'TEST1234567890', '110101', '', 'N', '5'); event.preventDefault();">
+                                <img src="//example.com/book-cover.jpg" alt="테스트 책 제목" onerror="this.src='/resources/common/images/L_NOBOOK.jpg'"/>
+                            </a>
+                            <p><a href="#" class="btn btn_s btn_line" onClick="javascript:contentList.fnContentPreview('N','001', '110101' ,'TEST1234567890','5', ''); event.preventDefault();" target="_blank" title="새 창으로 열림">미리보기</a></p>
+                        </div>
+                        <div>
+                            <p>
+                                <span class="store">TestStore</span>
+                            </p>
+                            <ul>
+                                <li class="tit"><a href="/content/contentView.ink" title="테스트 책 제목 | ASML 전자도서관" onClick="javascript:contentList.fnContentClick(this, '001', 'TEST1234567890', '110101', '', 'N'); event.preventDefault();">테스트 책 제목</a></li>
+                                <li class="writer">제이든<span>테스트 출판사</span>2024-01-01</li>
+                                <li class="txt">이것은 테스트 책의 설명입니다. 여기에 책의 줄거리나 소개가 들어갑니다. 이 책은 테스트를 위해 만들어진 가상의 책으로, 실제 존재하지 않습니다. 테스트 데이터의 구조와 형식을 보여주기 위한 목적으로 작성되었습니다.</li>
+                            </ul>
+                        </div>
+                        <div class="btn_area">
+                            <span><input type="button" name="brwBtn" value="대출" class="btn btn_mL btn_blue2" onClick="javascript:contentList.fnContentBorrow('N', '', '22705', '', 'TEST1234567890', '001', '테스트 책 제목','5', 'KB','1', '', event);"/></span>
+                            <span><input type="button" name="dibsBtn" value="찜" class="btn btn_mL btn_sel" onClick="javascript:contentList.fnDibs(this, 'TEST1234567890','N');"/></span>
+                        </div>
+                    </li>
+                </ul>
             """;
+
         setupPage(htmlContent);
 
         when(page.getUrl()).thenReturn(new PlainText(
@@ -160,6 +173,53 @@ public class BookPageProcessorTest {
         verify(bookQueueService, never()).addBookInfosToQueue(any());
         verify(booksCounter, never()).increment(anyLong());
         verify(pagesCounter, never()).increment();
+    }
+
+    @Test
+    @DisplayName("책 상세 페이지 URL 파싱 테스트")
+    void testParsingBookDetailUrl() {
+        // Given
+        String htmlContent = """
+                <ul class="book_resultList">
+                    <li>
+                        <div class="img">
+                            <a href="/content/contentView.ink" title="테스트 책 제목 | ASML 전자도서관" class="scale" onclick="javascript:contentList.fnContentClick(this, '001', 'TEST1234567890', '110101', '', 'N', '5'); event.preventDefault();">
+                                <img src="//example.com/book-cover.jpg" alt="테스트 책 제목" onerror="this.src='/resources/common/images/L_NOBOOK.jpg'"/>
+                            </a>
+                            <p><a href="#" class="btn btn_s btn_line" onClick="javascript:contentList.fnContentPreview('N','001', '110101' ,'TEST1234567890','5', ''); event.preventDefault();" target="_blank" title="새 창으로 열림">미리보기</a></p>
+                        </div>
+                        <div>
+                            <p>
+                                <span class="store">TestStore</span>
+                            </p>
+                            <ul>
+                                <li class="tit"><a href="/content/contentView.ink" title="테스트 책 제목 | ASML 전자도서관" onClick="javascript:contentList.fnContentClick(this, '001', 'TEST1234567890', '110101', '', 'N'); event.preventDefault();">테스트 책 제목</a></li>
+                                <li class="writer">제이든<span>테스트 출판사</span>2024-01-01</li>
+                                <li class="txt">이것은 테스트 책의 설명입니다. 여기에 책의 줄거리나 소개가 들어갑니다. 이 책은 테스트를 위해 만들어진 가상의 책으로, 실제 존재하지 않습니다. 테스트 데이터의 구조와 형식을 보여주기 위한 목적으로 작성되었습니다.</li>
+                            </ul>
+                        </div>
+                        <div class="btn_area">
+                            <span><input type="button" name="brwBtn" value="대출" class="btn btn_mL btn_blue2" onClick="javascript:contentList.fnContentBorrow('N', '', '22705', '', 'TEST1234567890', '001', '테스트 책 제목','5', 'KB','1', '', event);"/></span>
+                            <span><input type="button" name="dibsBtn" value="찜" class="btn btn_mL btn_sel" onClick="javascript:contentList.fnDibs(this, 'TEST1234567890','N');"/></span>
+                        </div>
+                    </li>
+                </ul>
+            """;
+        String expectedBookUrl = "https://example.com/content/contentView.ink?brcd=TEST1234567890&cttsDvsnCode=001";
+
+        setupPage(htmlContent);
+
+        when(page.getUrl()).thenReturn(new PlainText(
+            "https://example.com/content/contentList.ink?brcd=&sntnAuthCode=&contentAll=Y&cttsDvsnCode=001&ctgrId=&orderByKey=publDate&selViewCnt=20&pageIndex=1&recordCount=20"));
+
+        // When
+        bookPageProcessor.process(page);
+
+        // Then
+        verify(bookQueueService).addBookInfosToQueue(bookInfosCaptor.capture());
+        List<BookInfo> capturedBookInfos = bookInfosCaptor.getValue();
+        BookInfo bookInfo = capturedBookInfos.getFirst();
+        assertThat(bookInfo.getBookUrl()).isEqualTo(expectedBookUrl);
     }
 
 


### PR DESCRIPTION
## 변경 사항
- 책 상세페이지 URL을 파싱하고 저장하는 기능을 구현했습니다.

## 관련 이슈
#34 

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)


## 추가 설명
- 상세 페이지 URL을 위한 정보를 정규표현식을 이용해서 구현했습니다.
- 현재 도서관 페이지 HTML 형식에 하드코딩  되어있어서 좀 더 유연한 파싱 방법을 찾아봐야 할 것 같습니다.