### PR TITLE
[BE] 도서관마다 실제 책 개수와 저장된 개수를 비교하는 기능 및 api 구현

### DIFF
--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/controller/BookVerificationController.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/controller/BookVerificationController.java
@@ -1,0 +1,24 @@
+package com.meetyourbook.controller;
+
+import com.meetyourbook.dto.BookCountVerificationResult;
+import com.meetyourbook.service.BookCountVerificationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class BookVerificationController {
+
+    private final BookCountVerificationService bookCountVerificationService;
+
+    @GetMapping("/verify-book-count")
+    public List<BookCountVerificationResult> verifyBookCount() {
+        return bookCountVerificationService.checkBookCount();
+    }
+
+
+}

--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/dto/BookCountVerificationResult.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/dto/BookCountVerificationResult.java
@@ -1,0 +1,13 @@
+package com.meetyourbook.dto;
+
+public record BookCountVerificationResult(
+
+    Long libraryId,
+    String libraryName,
+    int actualBookCount,
+    int expectedBookCount,
+    boolean verified
+
+) {
+
+}

--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/dto/BookCountVerificationResult.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/dto/BookCountVerificationResult.java
@@ -1,5 +1,8 @@
 package com.meetyourbook.dto;
 
+import com.meetyourbook.entity.Library;
+import java.util.Map;
+
 public record BookCountVerificationResult(
 
     Long libraryId,
@@ -9,5 +12,19 @@ public record BookCountVerificationResult(
     boolean verified
 
 ) {
+
+    public static BookCountVerificationResult of(Library library,
+        Map<Long, Integer> actualBookCounts) {
+        int actualBookCount = actualBookCounts.getOrDefault(library.getId(), 0);
+        int expectedBookCount = library.getTotalBookCount();
+
+        return new BookCountVerificationResult(
+            library.getId(),
+            library.getName(),
+            actualBookCount,
+            expectedBookCount,
+            actualBookCount == expectedBookCount
+        );
+    }
 
 }

--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/repository/BookLibraryRepository.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/repository/BookLibraryRepository.java
@@ -1,8 +1,20 @@
 package com.meetyourbook.repository;
 
 import com.meetyourbook.entity.BookLibrary;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BookLibraryRepository extends JpaRepository<BookLibrary, Long> {
+
+    @Query("SELECT bl.library.id as libraryId, COUNT(bl.id) as bookCount FROM BookLibrary bl GROUP BY bl.library.id")
+    List<BookLibraryCount> getBookLibraryCount();
+
+    interface BookLibraryCount {
+
+        Long getLibraryId();
+
+        Integer getBookCount();
+    }
 
 }

--- a/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/service/BookCountVerificationService.java
+++ b/be/ebook-search/ebook-core/src/main/java/com/meetyourbook/service/BookCountVerificationService.java
@@ -30,22 +30,9 @@ public class BookCountVerificationService {
         List<Library> libraries = libraryRepository.findAll();
 
         return libraries.stream()
-            .map(library -> createBookCountVerificationResult(library, bookLibraryCounts))
+            .map(library -> BookCountVerificationResult.of(library, bookLibraryCounts))
             .toList();
 
     }
 
-    private BookCountVerificationResult createBookCountVerificationResult(Library library,
-        Map<Long, Integer> actualBookCounts) {
-        int actualBookCount = actualBookCounts.getOrDefault(library.getId(), 0);
-        int expectedBookCount = library.getTotalBookCount();
-
-        return new BookCountVerificationResult(
-            library.getId(),
-            library.getName(),
-            actualBookCount,
-            expectedBookCount,
-            actualBookCount == expectedBookCount
-        );
-    }
 }

--- a/be/ebook-search/ebook-core/src/test/java/com/meetyourbook/repository/BookLibraryRepositoryTest.java
+++ b/be/ebook-search/ebook-core/src/test/java/com/meetyourbook/repository/BookLibraryRepositoryTest.java
@@ -14,11 +14,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 @ActiveProfiles("test")
 @DataJpaTest
-@Transactional
 class BookLibraryRepositoryTest {
 
     @Autowired

--- a/be/ebook-search/ebook-core/src/test/java/com/meetyourbook/repository/BookLibraryRepositoryTest.java
+++ b/be/ebook-search/ebook-core/src/test/java/com/meetyourbook/repository/BookLibraryRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.meetyourbook.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.meetyourbook.entity.Book;
+import com.meetyourbook.entity.BookLibrary;
+import com.meetyourbook.entity.Library;
+import com.meetyourbook.repository.BookLibraryRepository.BookLibraryCount;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Transactional
+class BookLibraryRepositoryTest {
+
+    @Autowired
+    private LibraryRepository libraryRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private BookLibraryRepository bookLibraryRepository;
+
+    @Test
+    @DisplayName("도서관별 보유한 책의 수를 GroupBy로 조회한다.")
+    void getTotalBookCountByUsingGroupBy() {
+        // Given
+        Library library1 = Library.builder()
+            .name("Library 1")
+            .build();
+
+        libraryRepository.save(library1);
+
+        Book book1 = Book.builder().title("Book 1").build();
+        Book book2 = Book.builder().title("Book 2").build();
+
+        // Book 엔티티를 먼저 저장
+        bookRepository.saveAll(List.of(book1, book2));
+
+        BookLibrary bookLibrary1 = BookLibrary.createBookLibrary(
+            book1,
+            library1,
+            "https://example.com/book1"
+        );
+        BookLibrary bookLibrary2 = BookLibrary.createBookLibrary(
+            book2,
+            library1,
+            "https://example.com/book2"
+        );
+
+        bookLibraryRepository.saveAll(List.of(bookLibrary1, bookLibrary2));
+
+        // When
+        List<BookLibraryCount> bookLibraryCount = bookLibraryRepository.getBookLibraryCount();
+        Map<Long, Integer> result = bookLibraryCount.stream()
+            .collect(
+                Collectors.toMap(BookLibraryCount::getLibraryId, BookLibraryCount::getBookCount));
+
+        // Then
+        assertThat(result).containsEntry(library1.getId(), 2);
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 도서관 마다 총 책권수가 정확한지 비교하는 api 및 기능을 구현.

## 관련 이슈
#24 

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)
변경사항을 시각적으로 보여줄 수 있는 스크린샷이 있다면 여기에 추가해 주세요.

## 추가 설명
이 PR에 대해 리뷰어가 알아야 할 다른 정보가 있다면 여기에 적어주세요.