### PR TITLE
[BE] JSON 파일을 읽어 도서관 목록을 저장하는 기능 분리

### DIFF
--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/common/exception/CrawlerExceptionHandler.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/common/exception/CrawlerExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 @Slf4j
 @RestControllerAdvice
@@ -42,6 +43,15 @@ public class CrawlerExceptionHandler {
     @ExceptionHandler(JsonParseException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ResponseEntity<CrawlerErrorResponse> handleJsonParseException(
+        CrawlerNotRunningException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            new CrawlerErrorResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage(),
+                LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<CrawlerErrorResponse> handleMissingServletRequestPartException(
         CrawlerNotRunningException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
             new CrawlerErrorResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage(),

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/common/exception/CrawlerExceptionHandler.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/common/exception/CrawlerExceptionHandler.java
@@ -39,4 +39,13 @@ public class CrawlerExceptionHandler {
             ));
     }
 
+    @ExceptionHandler(JsonParseException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<CrawlerErrorResponse> handleJsonParseException(
+        CrawlerNotRunningException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+            new CrawlerErrorResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage(),
+                LocalDateTime.now()));
+    }
+
 }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/common/exception/JsonParseException.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/common/exception/JsonParseException.java
@@ -1,0 +1,8 @@
+package com.meetyourbook.common.exception;
+
+public class JsonParseException extends CrawlerException {
+
+    public JsonParseException() {
+        super("JSON 파일 형식이 올바르지 않습니다.");
+    }
+}

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/LibraryCrawlerController.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/LibraryCrawlerController.java
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LibraryCrawlerController {
 
+    public static final String JSON_FILE_PATH = "/Users/jeonbyeong-ung/IdeaProjects/meet-your-book/be/ebook-search/ebook-crawler/src/main/resources/library_list.json";
     private final LibraryImportService libraryImportService;
 
     @PostMapping("/save")
     public ResponseEntity<?> saveLibraryFromJson() {
-        libraryImportService.saveLibraryFromJson(
-            "/Users/jeonbyeong-ung/IdeaProjects/meet-your-book/be/ebook-search/ebook-crawler/src/main/resources/library_list.json");
+        libraryImportService.saveLibraryFromJson(JSON_FILE_PATH);
         return ResponseEntity.ok().build();
     }
 }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/LibraryCrawlerController.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/LibraryCrawlerController.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,7 +18,7 @@ public class LibraryCrawlerController {
     private final LibraryImportService libraryImportService;
 
     @PostMapping("/import")
-    public ResponseEntity<?> saveLibraryFromJson(@RequestParam("file") MultipartFile file) {
+    public ResponseEntity<?> saveLibraryFromJson(@RequestPart("file") MultipartFile file) {
         int importedCount = libraryImportService.importLibrariesFromJson(file);
         return ResponseEntity.ok(new ImportResult(importedCount, "도서관 정보를 성공적으로 저장했습니다."));
     }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/LibraryCrawlerController.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/LibraryCrawlerController.java
@@ -1,23 +1,25 @@
 package com.meetyourbook.controller;
 
+import com.meetyourbook.dto.ImportResult;
 import com.meetyourbook.service.LibraryImportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/library-crawler")
 @RequiredArgsConstructor
 public class LibraryCrawlerController {
 
-    public static final String JSON_FILE_PATH = "/Users/jeonbyeong-ung/IdeaProjects/meet-your-book/be/ebook-search/ebook-crawler/src/main/resources/library_list.json";
     private final LibraryImportService libraryImportService;
 
-    @PostMapping("/save")
-    public ResponseEntity<?> saveLibraryFromJson() {
-        libraryImportService.saveLibraryFromJson(JSON_FILE_PATH);
-        return ResponseEntity.ok().build();
+    @PostMapping("/import")
+    public ResponseEntity<?> saveLibraryFromJson(@RequestParam("file") MultipartFile file) {
+        int importedCount = libraryImportService.importLibrariesFromJson(file);
+        return ResponseEntity.ok(new ImportResult(importedCount, "도서관 정보를 성공적으로 저장했습니다."));
     }
 }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/dto/ImportResult.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/dto/ImportResult.java
@@ -1,0 +1,5 @@
+package com.meetyourbook.dto;
+
+public record ImportResult (int importedCount, String message) {
+
+}

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/service/LibraryImportService.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/service/LibraryImportService.java
@@ -1,5 +1,8 @@
 package com.meetyourbook.service;
 
+import com.meetyourbook.dto.LibraryCreationInfo;
+import com.meetyourbook.util.JsonConvertor;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,10 +10,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LibraryImportService {
 
-    private final LibraryDomainService libraryDomainService;
+    private final LibraryDomainService libraryService;
+    private final JsonConvertor jsonConvertor;
 
     public void saveLibraryFromJson(String path) {
-        libraryDomainService.saveLibraryFromJson(path);
+        List<LibraryCreationInfo> libraryCreationInfos = jsonConvertor.readFromJson(path);
+        libraryService.createLibraries(libraryCreationInfos);
     }
 
 }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/service/LibraryImportService.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/service/LibraryImportService.java
@@ -5,17 +5,20 @@ import com.meetyourbook.util.JsonConvertor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class LibraryImportService {
 
-    private final LibraryDomainService libraryService;
+    private final LibraryDomainService libraryDomainService;
     private final JsonConvertor jsonConvertor;
 
-    public void saveLibraryFromJson(String path) {
-        List<LibraryCreationInfo> libraryCreationInfos = jsonConvertor.readFromJson(path);
-        libraryService.createLibraries(libraryCreationInfos);
+    public int importLibrariesFromJson(MultipartFile file) {
+        List<LibraryCreationInfo> libraryCreationInfos = jsonConvertor.parseJsonFile(file,
+            LibraryCreationInfo.class);
+
+        return libraryDomainService.createLibraries(libraryCreationInfos);
     }
 
 }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/service/LibraryImportService.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/service/LibraryImportService.java
@@ -1,7 +1,7 @@
 package com.meetyourbook.service;
 
 import com.meetyourbook.dto.LibraryCreationInfo;
-import com.meetyourbook.util.JsonConvertor;
+import com.meetyourbook.util.JsonParser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class LibraryImportService {
 
     private final LibraryDomainService libraryDomainService;
-    private final JsonConvertor jsonConvertor;
+    private final JsonParser jsonConvertor;
 
     public int importLibrariesFromJson(MultipartFile file) {
         List<LibraryCreationInfo> libraryCreationInfos = jsonConvertor.parseJsonFile(file,

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/util/JsonConvertor.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/util/JsonConvertor.java
@@ -1,0 +1,38 @@
+package com.meetyourbook.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetyourbook.dto.LibraryCreationInfo;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JsonConvertor {
+
+    private final ObjectMapper objectMapper;
+
+    public List<LibraryCreationInfo> readFromJson(String filePath) {
+        try {
+            List<LibraryCreationInfo> libraryCreationInfos = readLibraryCreationsFromJson(filePath);
+            log.info("Successfully read {} libraries", libraryCreationInfos.size());
+            return libraryCreationInfos;
+        } catch (IOException e) {
+            log.error("Error reading JSON file: {}", filePath, e);
+            throw new RuntimeException("Failed to read library data from JSON", e);
+        }
+    }
+
+    private List<LibraryCreationInfo> readLibraryCreationsFromJson(String filePath)
+        throws IOException {
+
+        return objectMapper.readValue(new File(filePath), new TypeReference<>() {});
+    }
+
+
+}

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/util/JsonConvertor.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/util/JsonConvertor.java
@@ -1,14 +1,14 @@
 package com.meetyourbook.util;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.meetyourbook.dto.LibraryCreationInfo;
-import java.io.File;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.meetyourbook.common.exception.JsonParseException;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 @Component
 @RequiredArgsConstructor
@@ -17,22 +17,13 @@ public class JsonConvertor {
 
     private final ObjectMapper objectMapper;
 
-    public List<LibraryCreationInfo> readFromJson(String filePath) {
+    public <T> List<T> parseJsonFile(MultipartFile file, Class<T> targetClass) {
         try {
-            List<LibraryCreationInfo> libraryCreationInfos = readLibraryCreationsFromJson(filePath);
-            log.info("Successfully read {} libraries", libraryCreationInfos.size());
-            return libraryCreationInfos;
+            CollectionType listType = objectMapper.getTypeFactory().constructCollectionType(List.class, targetClass);
+            return objectMapper.readValue(file.getInputStream(), listType);
         } catch (IOException e) {
-            log.error("Error reading JSON file: {}", filePath, e);
-            throw new RuntimeException("Failed to read library data from JSON", e);
+            throw new JsonParseException();
         }
     }
-
-    private List<LibraryCreationInfo> readLibraryCreationsFromJson(String filePath)
-        throws IOException {
-
-        return objectMapper.readValue(new File(filePath), new TypeReference<>() {});
-    }
-
 
 }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/util/JsonParser.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/util/JsonParser.java
@@ -13,7 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class JsonConvertor {
+public class JsonParser {
 
     private final ObjectMapper objectMapper;
 

--- a/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/controller/LibraryCrawlerControllerTest.java
+++ b/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/controller/LibraryCrawlerControllerTest.java
@@ -1,0 +1,61 @@
+package com.meetyourbook.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.meetyourbook.service.LibraryImportService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+
+@WebMvcTest(LibraryCrawlerController.class)
+class LibraryCrawlerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LibraryImportService libraryImportService;
+
+    @Test
+    @DisplayName("JSON 파일 업로드 시 저장한 도서관 수를 반환한다.")
+    void saveLibraryFromJson() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "test-libraries.json",
+            MediaType.APPLICATION_JSON_VALUE,
+            "{\"test\": \"data\"}".getBytes()
+        );
+
+        when(libraryImportService.importLibrariesFromJson(any(MultipartFile.class))).thenReturn(10);
+
+        // when & then
+        mockMvc.perform(multipart("/api/library-crawler/import").file(file))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.importedCount").value(10))
+            .andExpect(jsonPath("$.message").value("도서관 정보를 성공적으로 저장했습니다."));
+    }
+
+    @Test
+    @DisplayName("파일 없이 요청 시 BAD REQUEST 를 반환한다.")
+    void saveLibraryFromJsonWithoutFile() throws Exception {
+        // when & then
+        mockMvc.perform(multipart("/api/library-crawler/import"))
+            .andExpect(status().isBadRequest())
+            .andExpect(result -> assertThat(result.getResolvedException() instanceof MissingServletRequestPartException).isTrue())
+            .andExpect(result -> assertThat(result.getResolvedException().getMessage()).isEqualTo("Required part 'file' is not present."));
+    }
+
+}

--- a/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/service/LibraryImportServiceTest.java
+++ b/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/service/LibraryImportServiceTest.java
@@ -1,0 +1,71 @@
+package com.meetyourbook.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetyourbook.entity.Library;
+import com.meetyourbook.entity.Library.LibraryType;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+
+@SpringBootTest
+class LibraryImportServiceTest {
+
+    @Autowired
+    private LibraryImportService libraryImportService;
+
+    @MockBean
+    private LibraryDomainService libraryDomainService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("JSON 파일을 읽어 저장한 도서관 수를 반환한다.")
+    void testImportLibrariesFromJson() throws IOException {
+        // given
+        List<Library> testLibraries = generateTestLibraries(20); // 테스트 데이터 생성
+        String jsonContent = objectMapper.writeValueAsString(testLibraries);
+        MockMultipartFile jsonFile = new MockMultipartFile("file", "test-libraries.json",
+            "application/json", jsonContent.getBytes());
+        when(libraryDomainService.createLibraries(any())).thenReturn(testLibraries.size());
+
+        // when
+        int importedCount = libraryImportService.importLibrariesFromJson(jsonFile);
+
+        // then
+        assertThat(importedCount).isEqualTo(testLibraries.size());
+    }
+
+    private List<Library> generateTestLibraries(int count) {
+        List<Library> libraries = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            libraries.add(createDummyLibrary());
+        }
+
+        return libraries;
+    }
+
+    private Library createDummyLibrary() {
+        UUID uuid = UUID.randomUUID();
+        return Library.builder()
+            .name("도서관 " + uuid.toString().substring(0, 8))
+            .libraryUrl("http://library" + uuid.toString().substring(0, 8) + ".com")
+            .totalBookCount((int) (Math.random() * 10000) + 1000)
+            .type(LibraryType.CORPORATE_LIBRARY)
+            .build();
+    }
+
+
+}

--- a/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/util/JsonParserTest.java
+++ b/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/util/JsonParserTest.java
@@ -1,0 +1,76 @@
+package com.meetyourbook.util;
+
+import static org.assertj.core.groups.Tuple.tuple;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetyourbook.common.exception.JsonParseException;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+class JsonParserTest {
+
+    private JsonParser jsonConvertor;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        jsonConvertor = new JsonParser(objectMapper);
+    }
+
+    @Test
+    @DisplayName("JSON 파일과 클래스 타입을 입력받아 파싱한다.")
+    void parseJsonFile() {
+        // Given
+        String jsonContent = "[{\"name\":\"Jayden\",\"age\":27},{\"name\":\"George\",\"age\":29}]";
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "test.json", "application/json", jsonContent.getBytes()
+        );
+
+        // When
+        List<TestData> result = jsonConvertor.parseJsonFile(file, TestData.class);
+
+        // Then
+        Assertions.assertThat(result).hasSize(2)
+            .extracting(
+                TestData::getName,
+                TestData::getAge
+            )
+            .containsExactlyInAnyOrder(
+                tuple("Jayden", 27),
+                tuple("George", 29)
+            );
+    }
+
+    @Test
+    @DisplayName("JSON 파일 형식이 올바르지 않을 경우 JsonParseException를 발생시킨다.")
+    void parseInvalidJsonFile() {
+        // Given
+        String invalidJsonContent = "This is not a valid JSON";
+        MockMultipartFile file = new MockMultipartFile(
+            "file", "invalid.json", "application/json", invalidJsonContent.getBytes()
+        );
+
+        // When & Then
+        Assertions.assertThatThrownBy(() -> jsonConvertor.parseJsonFile(file, TestData.class))
+            .isInstanceOf(JsonParseException.class);
+    }
+
+    private static class TestData {
+
+        private String name;
+        private int age;
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+    }
+
+}

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/dto/LibraryCreationInfo.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/dto/LibraryCreationInfo.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 
 @Builder
 public record LibraryCreationInfo(
-
     String category,
     String name,
     String url

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/service/LibraryDomainService.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/service/LibraryDomainService.java
@@ -1,15 +1,11 @@
 package com.meetyourbook.service;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meetyourbook.dto.LibraryCreationInfo;
 import com.meetyourbook.dto.LibraryResponse;
 import com.meetyourbook.dto.LibraryUpdateInfo;
 import com.meetyourbook.entity.Library;
 import com.meetyourbook.exception.ResourceNotFoundException;
 import com.meetyourbook.repository.LibraryRepository;
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class LibraryDomainService {
 
     private final LibraryRepository libraryRepository;
-    private final ObjectMapper objectMapper;
 
     @Transactional(readOnly = true)
     public List<Library> findAll() {
@@ -34,6 +29,14 @@ public class LibraryDomainService {
     public Long createLibrary(LibraryCreationInfo creationInfo) {
         Library library = libraryRepository.save(creationInfo.toEntity());
         return library.getId();
+    }
+
+    @Transactional
+    public void createLibraries(List<LibraryCreationInfo> libraryCreationInfos) {
+        List<Library> libraries = libraryCreationInfos.stream()
+            .map(LibraryCreationInfo::toEntity)
+            .toList();
+        libraryRepository.saveAll(libraries);
     }
 
     @Transactional
@@ -74,31 +77,6 @@ public class LibraryDomainService {
     public Library findByBaseUrl(String baseUrl) {
         return libraryRepository.findByLibraryUrl_UrlContaining(baseUrl)
             .orElseThrow(() -> new NoSuchElementException("base Url not found = " + baseUrl));
-    }
-
-    @Transactional
-    public void saveLibraryFromJson(String filePath) {
-        try {
-            List<LibraryCreationInfo> libraryCreationInfos = readLibraryCreationsFromJson(filePath);
-            List<Library> libraries = convertToLibraries(libraryCreationInfos);
-            libraryRepository.saveAll(libraries);
-            log.info("Successfully saved {} libraries", libraries.size());
-        } catch (IOException e) {
-            log.error("Error reading JSON file: {}", filePath, e);
-            throw new RuntimeException("Failed to read library data from JSON", e);
-        }
-    }
-
-    private List<LibraryCreationInfo> readLibraryCreationsFromJson(String filePath)
-        throws IOException {
-        return objectMapper.readValue(new File(filePath), new TypeReference<>() {
-        });
-    }
-
-    private List<Library> convertToLibraries(List<LibraryCreationInfo> libraryCreationInfos) {
-        return libraryCreationInfos.stream()
-            .map(LibraryCreationInfo::toEntity)
-            .toList();
     }
 
     private Library findLibrary(Long id) {

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/service/LibraryDomainService.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/service/LibraryDomainService.java
@@ -32,11 +32,13 @@ public class LibraryDomainService {
     }
 
     @Transactional
-    public void createLibraries(List<LibraryCreationInfo> libraryCreationInfos) {
+    public int createLibraries(List<LibraryCreationInfo> libraryCreationInfos) {
         List<Library> libraries = libraryCreationInfos.stream()
             .map(LibraryCreationInfo::toEntity)
             .toList();
-        libraryRepository.saveAll(libraries);
+
+        List<Library> savedLibraries = libraryRepository.saveAll(libraries);
+        return savedLibraries.size();
     }
 
     @Transactional

--- a/be/ebook-search/ebook-domain/src/test/java/com/meetyourbook/service/LibraryDomainServiceTest.java
+++ b/be/ebook-search/ebook-domain/src/test/java/com/meetyourbook/service/LibraryDomainServiceTest.java
@@ -4,7 +4,6 @@ import static com.meetyourbook.entity.Library.LibraryType.PUBLIC_LIBRARY;
 import static com.meetyourbook.entity.Library.LibraryType.UNIVERSITY_LIBRARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.meetyourbook.common.RepositoryTest;
 import com.meetyourbook.dto.LibraryCreationInfo;
 import com.meetyourbook.dto.LibraryResponse;
@@ -23,14 +22,12 @@ class LibraryDomainServiceTest {
 
     private LibraryDomainService libraryDomainService;
 
-    private ObjectMapper objectMapper;
-
     @Autowired
     private LibraryRepository libraryRepository;
 
     @BeforeEach
     void setUp() {
-        libraryDomainService = new LibraryDomainService(libraryRepository, objectMapper);
+        libraryDomainService = new LibraryDomainService(libraryRepository);
     }
 
     @AfterEach


### PR DESCRIPTION
## 변경 사항
- `LibraryDomainService`의 `saveLibraryFromJson` 메서드를 JSON 파일을 읽는 메서드와 도서관 목록을 저장하는 메서드로 분리
- JSON 파일을 읽는 메서드를 `JsonParser` 클래스로 분리
- JSON 파일의 경로가 아닌 파일을 받도록 기능 변경
- JSON 파일을 업로드 하지 않을 시 발생하는 `MissingServletRequestPartException` 예외 처리 추가
- JSON 파일 파싱 작업 시 발생하는 예외 추가
- 관련 테스트 코드 작성

## 관련 이슈
#49 

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [x] 리팩토링
- [ ] 문서 내용 변경
- [x] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)