### PR TITLE
[FE] 모바일 반응형 구현

### DIFF
--- a/fe/src/components/BooksDisplay/BookCard/BookCard.tsx
+++ b/fe/src/components/BooksDisplay/BookCard/BookCard.tsx
@@ -39,7 +39,7 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
             ) : (
                 <S.ListCard $isVisible={isVisible}>
                     <S.Image
-                        src={`http://${imageUrl}`}
+                        src={`http://${imageUrl}11`}
                         alt={title}
                         onError={handleImageError}
                     />

--- a/fe/src/components/Navigation/MobileSearchFilterPanel/MobileSearchFilterPanel.tsx
+++ b/fe/src/components/Navigation/MobileSearchFilterPanel/MobileSearchFilterPanel.tsx
@@ -1,0 +1,38 @@
+import FilterDisplay from "@/components/FilterDisplay/FilterDisplay";
+import * as S from "@/styles/MobileSearchFilterPanelStyle";
+import { useState } from "react";
+import SearchInput from "../SearchInput/SearchInput";
+
+export const MobileSearchFilterPanel = () => {
+    const [isFilterOpen, setFilterOpen] = useState(false);
+    const [isSearchOpen, setSearchOpen] = useState(false);
+
+    const closePanels = () => {
+        setFilterOpen(false);
+        setSearchOpen(false);
+    };
+    return (
+        <S.PanelContainer>
+            <S.CustomSearchIcon onClick={() => setSearchOpen(!isSearchOpen)} />
+            <S.CustomFilterIcon onClick={() => setFilterOpen(!isFilterOpen)} />
+
+            {(isFilterOpen || isSearchOpen) && (
+                <S.Overlay onClick={closePanels} />
+            )}
+            
+            <S.FilterWrap $isFilterOpen={isFilterOpen}>
+                <S.CancelBtn onClick={() => setFilterOpen(false)}>
+                    X
+                </S.CancelBtn>
+                <FilterDisplay />
+            </S.FilterWrap>
+
+            <S.SearchWrap $isSearchOpen={isSearchOpen}>
+                <SearchInput />
+                <S.CancelBtn onClick={() => setSearchOpen(false)}>
+                    X
+                </S.CancelBtn>
+            </S.SearchWrap>
+        </S.PanelContainer>
+    );
+};

--- a/fe/src/components/Navigation/Navigation.tsx
+++ b/fe/src/components/Navigation/Navigation.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import SearchInput from "./SearchInput/SearchInput";
 import * as S from "@/styles/NavigationStyle";
+import { MobileSearchFilterPanel } from "./MobileSearchFilterPanel/MobileSearchFilterPanel";
 
 const Navigation = () => {
     const navigate = useNavigate();
@@ -14,7 +15,10 @@ const Navigation = () => {
                 <S.LogoWrap onClick={goToMain}>
                     <S.LogoName>Meet Your Book</S.LogoName>
                 </S.LogoWrap>
-                <SearchInput/>
+                <S.SearchWrap>
+                    <SearchInput />
+                </S.SearchWrap>
+                <MobileSearchFilterPanel />
             </S.NavWrap>
         </S.NavContainer>
     );

--- a/fe/src/components/Navigation/Navigation.tsx
+++ b/fe/src/components/Navigation/Navigation.tsx
@@ -1,27 +1,20 @@
 import { useNavigate } from "react-router-dom";
-import DropDownBox from "./DropDownBox/DropDownBox";
 import SearchInput from "./SearchInput/SearchInput";
 import * as S from "@/styles/NavigationStyle";
 
-
 const Navigation = () => {
-    const navigate = useNavigate()
+    const navigate = useNavigate();
 
-    const goToLogin = () => {
-        navigate("/Login")
-    }
+    const goToMain = () => {
+        navigate("/");
+    };
     return (
         <S.NavContainer>
             <S.NavWrap>
-                <S.LogoWrap>
-                    <S.LogoAbbreviation>MYB</S.LogoAbbreviation>
-                    <S.LogoFullName>MeetYourBook</S.LogoFullName>
+                <S.LogoWrap onClick={goToMain}>
+                    <S.LogoName>Meet Your Book</S.LogoName>
                 </S.LogoWrap>
-                <S.InputWrap>
-                    <DropDownBox/>
-                    <SearchInput/>
-                </S.InputWrap>
-                <S.LoginBtn onClick={goToLogin}>로그인</S.LoginBtn>
+                <SearchInput/>
             </S.NavWrap>
         </S.NavContainer>
     );

--- a/fe/src/components/Navigation/Navigation.tsx
+++ b/fe/src/components/Navigation/Navigation.tsx
@@ -3,18 +3,24 @@ import SearchInput from "./SearchInput/SearchInput";
 import * as S from "@/styles/NavigationStyle";
 import { MobileSearchFilterPanel } from "./MobileSearchFilterPanel/MobileSearchFilterPanel";
 
-const Navigation = () => {
+export const Logo = () => {
     const navigate = useNavigate();
 
     const goToMain = () => {
         navigate("/");
     };
     return (
+        <S.LogoWrap onClick={goToMain}>
+            <S.LogoName>Meet Your Book</S.LogoName>
+        </S.LogoWrap>
+    );
+};
+
+const Navigation = () => {
+    return (
         <S.NavContainer>
             <S.NavWrap>
-                <S.LogoWrap onClick={goToMain}>
-                    <S.LogoName>Meet Your Book</S.LogoName>
-                </S.LogoWrap>
+                <Logo/>
                 <S.SearchWrap>
                     <SearchInput />
                 </S.SearchWrap>

--- a/fe/src/components/Navigation/SearchInput/SearchInput.tsx
+++ b/fe/src/components/Navigation/SearchInput/SearchInput.tsx
@@ -3,6 +3,7 @@ import { KeyboardEvent, useRef } from "react";
 import useQueryStore from "@/stores/queryStore";
 import { SearchOutlined } from "@ant-design/icons";
 import { FIRST_PAGE } from "@/constants";
+import DropDownBox from "../DropDownBox/DropDownBox";
 
 const SearchInput = () => {
     const inputRef = useRef<HTMLInputElement>(null);
@@ -20,7 +21,8 @@ const SearchInput = () => {
     };
 
     return (
-        <>
+        <S.InputWrap>
+            <DropDownBox/>
             <S.InputField
                 ref={inputRef}
                 onKeyDown={handleKeyDown}
@@ -29,7 +31,7 @@ const SearchInput = () => {
             <S.SearchField onClick={handleSearchClick}>
                 <SearchOutlined />
             </S.SearchField>
-        </>
+        </S.InputWrap>
     );
 };
 

--- a/fe/src/pages/Home.tsx
+++ b/fe/src/pages/Home.tsx
@@ -5,7 +5,9 @@ import styled from "styled-components";
 const Home = () => {
     return (
         <HomeContainer>
-            <FilterDisplay />
+            <FilterWrap>
+                <FilterDisplay />
+            </FilterWrap>
             <BooksDisplay />
         </HomeContainer>
     );
@@ -20,8 +22,11 @@ const HomeContainer = styled.main`
     justify-content: center;
     gap: 2rem;
     margin: 0px auto;
-
-    @media (max-width: 768px) {
-        width: 100%;
-    }
 `;
+
+const FilterWrap = styled.div`
+    @media (max-width: 768px) {
+        display: none;
+    }
+`
+

--- a/fe/src/pages/Home.tsx
+++ b/fe/src/pages/Home.tsx
@@ -19,5 +19,9 @@ const HomeContainer = styled.main`
     display: flex;
     justify-content: center;
     gap: 2rem;
-    margin: 0px auto
+    margin: 0px auto;
+
+    @media (max-width: 768px) {
+        width: 100%;
+    }
 `;

--- a/fe/src/pages/Home.tsx
+++ b/fe/src/pages/Home.tsx
@@ -22,10 +22,13 @@ const HomeContainer = styled.main`
     justify-content: center;
     gap: 2rem;
     margin: 0px auto;
+    @media (max-width: 1024px) {
+        gap: 0;
+    }
 `;
 
 const FilterWrap = styled.div`
-    @media (max-width: 768px) {
+    @media (max-width: 1000px) {
         display: none;
     }
 `

--- a/fe/src/pages/Login.tsx
+++ b/fe/src/pages/Login.tsx
@@ -1,47 +1,52 @@
 import { useNavigate } from "react-router-dom";
 import * as S from "@/styles/AuthFormStyle";
 import BackButton from "@/components/BackButton/BackButton";
+import { Logo } from "@/components/Navigation/Navigation";
 const Login = () => {
     const navigate = useNavigate();
     const goToSignUp = () => {
         navigate("/SignUp");
     };
     return (
-        <S.AuthContainer>
-            <S.AuthCard>
-                <S.Header>
-                    <BackButton/>
-                    <S.AuthTitle>Login</S.AuthTitle>
-
-                </S.Header>
-                <S.AuthForm>
-                    <S.FormGroup>
-                        <S.Label>ID</S.Label>
-                        <S.Input
-                            id="ID"
-                            type="ID"
-                            placeholder="Enter your ID"
-                        />
-                    </S.FormGroup>
-                    <S.FormGroup>
-                        <S.Label>Password</S.Label>
-                        <S.Input
-                            id="password"
-                            type="password"
-                            placeholder="Enter your password"
-                        />
-                    </S.FormGroup>
-                    <S.Button>Login</S.Button>
-                    <S.AuthButton>Sign in with Google</S.AuthButton>
-                    <S.SignUpText>
-                        Don't have an account?{" "}
-                        <S.SignUpLink onClick={goToSignUp}>
-                            Sign up
-                        </S.SignUpLink>
-                    </S.SignUpText>
-                </S.AuthForm>
-            </S.AuthCard>
-        </S.AuthContainer>
+        <>
+            <S.LogoWrap>
+                <Logo />
+            </S.LogoWrap>
+            <S.AuthContainer>
+                <S.AuthCard>
+                    <S.Header>
+                        <BackButton />
+                        <S.AuthTitle>Login</S.AuthTitle>
+                    </S.Header>
+                    <S.AuthForm>
+                        <S.FormGroup>
+                            <S.Label>ID</S.Label>
+                            <S.Input
+                                id="ID"
+                                type="ID"
+                                placeholder="Enter your ID"
+                            />
+                        </S.FormGroup>
+                        <S.FormGroup>
+                            <S.Label>Password</S.Label>
+                            <S.Input
+                                id="password"
+                                type="password"
+                                placeholder="Enter your password"
+                            />
+                        </S.FormGroup>
+                        <S.Button>Login</S.Button>
+                        <S.AuthButton>Sign in with Google</S.AuthButton>
+                        <S.SignUpText>
+                            Don't have an account?{" "}
+                            <S.SignUpLink onClick={goToSignUp}>
+                                Sign up
+                            </S.SignUpLink>
+                        </S.SignUpText>
+                    </S.AuthForm>
+                </S.AuthCard>
+            </S.AuthContainer>
+        </>
     );
 };
 

--- a/fe/src/pages/SignUp.tsx
+++ b/fe/src/pages/SignUp.tsx
@@ -1,43 +1,49 @@
 import BackButton from "@/components/BackButton/BackButton";
+import { Logo } from "@/components/Navigation/Navigation";
 import * as S from "@/styles/AuthFormStyle";
 
 const SignUp = () => {
     return (
-        <S.AuthContainer>
-            <S.AuthCard>
-            <S.Header>
-                    <BackButton/>
-                    <S.AuthTitle>Sign Up</S.AuthTitle>
-                </S.Header>
-                <S.AuthForm>
-                    <S.FormGroup>
-                        <S.Label>Name</S.Label>
-                        <S.Input
-                            id="Name"
-                            type="text"
-                            placeholder="Enter your Name"
-                        />
-                    </S.FormGroup>
-                    <S.FormGroup>
-                        <S.Label>ID</S.Label>
-                        <S.Input
-                            id="ID"
-                            type="text"
-                            placeholder="Enter your ID"
-                        />
-                    </S.FormGroup>
-                    <S.FormGroup>
-                        <S.Label>Password</S.Label>
-                        <S.Input
-                            id="password"
-                            type="password"
-                            placeholder="Enter your password"
-                        />
-                    </S.FormGroup>
-                    <S.Button>Sign Up</S.Button>
-                </S.AuthForm>
-            </S.AuthCard>
-        </S.AuthContainer>
+        <>
+            <S.LogoWrap>
+                <Logo />
+            </S.LogoWrap>
+            <S.AuthContainer>
+                <S.AuthCard>
+                    <S.Header>
+                        <BackButton />
+                        <S.AuthTitle>Sign Up</S.AuthTitle>
+                    </S.Header>
+                    <S.AuthForm>
+                        <S.FormGroup>
+                            <S.Label>Name</S.Label>
+                            <S.Input
+                                id="Name"
+                                type="text"
+                                placeholder="Enter your Name"
+                            />
+                        </S.FormGroup>
+                        <S.FormGroup>
+                            <S.Label>ID</S.Label>
+                            <S.Input
+                                id="ID"
+                                type="text"
+                                placeholder="Enter your ID"
+                            />
+                        </S.FormGroup>
+                        <S.FormGroup>
+                            <S.Label>Password</S.Label>
+                            <S.Input
+                                id="password"
+                                type="password"
+                                placeholder="Enter your password"
+                            />
+                        </S.FormGroup>
+                        <S.Button>Sign Up</S.Button>
+                    </S.AuthForm>
+                </S.AuthCard>
+            </S.AuthContainer>
+        </>
     );
 };
 

--- a/fe/src/stories/SearchInput.stories.tsx
+++ b/fe/src/stories/SearchInput.stories.tsx
@@ -1,28 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import SearchInput from "@/components/Navigation/SearchInput/SearchInput";
-import styled from "styled-components";
-
-const StoryContainer = styled.div`
-    width: 100%;
-    max-width: 1200px;
-    margin: 0 auto;
-    display: flex;
-    border: 1px solid #e9e7e7;
-    border-radius: 8px;
-    padding: 5px;
-    align-items: center;
-`;
 
 const meta = {
     title: "Components/SearchInput",
     component: SearchInput,
-    decorators: [
-        (Story) => (
-            <StoryContainer>
-                <Story />
-            </StoryContainer>
-        ),
-    ],
     parameters: {
         layout: "centered",
     },

--- a/fe/src/styles/AuthFormStyle.ts
+++ b/fe/src/styles/AuthFormStyle.ts
@@ -4,9 +4,7 @@ const AuthContainer = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
-    min-height: 100vh;
     padding: 16px;
-    background-color: #f9fafb;
 `;
 
 const AuthCard = styled.div`
@@ -23,8 +21,8 @@ const Header = styled.div`
     align-items: center;
     justify-content: space-between;
     margin-bottom: 25px;
-    padding: 0px 2px
-`
+    padding: 0px 2px;
+`;
 
 const AuthTitle = styled.h2`
     font-size: 1.25rem;
@@ -60,14 +58,14 @@ const Input = styled.input`
 const Button = styled.button`
     width: 100%;
     padding: 10px;
-    background-color: #22C55E;
+    background-color: #22c55e;
     color: white;
     border-radius: 8px;
     border: none;
     font-size: 1rem;
     cursor: pointer;
     &:hover {
-        background-color: #16A34A;
+        background-color: #16a34a;
     }
 `;
 
@@ -101,6 +99,10 @@ const SignUpLink = styled.span`
     }
 `;
 
+const LogoWrap = styled.div`
+    padding: 30px;
+`;
+
 export {
     AuthContainer,
     AuthCard,
@@ -113,5 +115,6 @@ export {
     AuthButton,
     SignUpText,
     SignUpLink,
-    Header
+    Header,
+    LogoWrap,
 };

--- a/fe/src/styles/BookCardStyle.ts
+++ b/fe/src/styles/BookCardStyle.ts
@@ -6,6 +6,7 @@ const Card = styled.div<{ $isVisible: boolean }>`
     border: 1px solid #d1d5db;
     border-radius: 0.375rem;
     padding: 0.3rem;
+    margin: 0 auto;
     box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.05);
     transition:
         opacity 0.2s ease-in-out,

--- a/fe/src/styles/BookCardStyle.ts
+++ b/fe/src/styles/BookCardStyle.ts
@@ -36,7 +36,6 @@ const Image = styled.img`
     height: 13rem;
     border-radius: 0.375rem;
     margin: auto;
-    margin-bottom: 0.5rem;
 `;
 
 const TextContainer = styled.div<{ $viewMode: ViewType }>`
@@ -51,7 +50,7 @@ const TextContainer = styled.div<{ $viewMode: ViewType }>`
 const Title = styled.h3`
     font-weight: bold;
     font-size: 0.875rem;
-    margin-bottom: 0.25rem;
+    margin: 0.25rem 0;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/fe/src/styles/BookDisplayStyle.ts
+++ b/fe/src/styles/BookDisplayStyle.ts
@@ -18,7 +18,7 @@ const BookWrap = styled.div<{ $viewMode: ViewType }>`
     grid-template-columns: ${({ $viewMode }) =>
         $viewMode === "grid" ? "repeat(4, 1fr)" : "none"};
     gap: 15px;
-
+    justify-content: center;
     @media (max-width: 600px) {
         grid-template-columns: repeat(2, 1fr);
         gap: 10px;

--- a/fe/src/styles/BookDisplayStyle.ts
+++ b/fe/src/styles/BookDisplayStyle.ts
@@ -2,9 +2,15 @@ import styled from "styled-components";
 import { ViewType } from "./ViewSelectorStyle";
 
 const BookContainer = styled.div`
-    width: 750px;
-    min-width: 750px;
-    
+width: 750px;
+@media (max-width: 768px) {
+    width: 100%;
+    padding: 20px;
+}
+@media (max-width: 600px) {
+    max-width: 330px;
+    margin: 0 auto;
+}
 `;
 
 const BookWrap = styled.div<{ $viewMode: ViewType }>`
@@ -12,6 +18,11 @@ const BookWrap = styled.div<{ $viewMode: ViewType }>`
     grid-template-columns: ${({ $viewMode }) =>
         $viewMode === "grid" ? "repeat(4, 1fr)" : "none"};
     gap: 15px;
+
+    @media (max-width: 600px) {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 10px;
+    }
 `;
 
 const LastPageView = styled.div`

--- a/fe/src/styles/FilterDisplay.ts
+++ b/fe/src/styles/FilterDisplay.ts
@@ -2,6 +2,10 @@ import styled from "styled-components";
 
 const FilterContainer = styled.div`
     min-width: 240px;
+
+    @media (max-width: 768px) {
+        margin: auto;
+    }
 `;
 
 const Title = styled.h1`

--- a/fe/src/styles/MobileSearchFilterPanelStyle.ts
+++ b/fe/src/styles/MobileSearchFilterPanelStyle.ts
@@ -1,0 +1,85 @@
+import styled from "styled-components";
+import { SearchOutlined, FilterOutlined } from "@ant-design/icons";
+
+const PanelContainer = styled.div`
+    display: none;
+    padding: 0 16px;
+    @media (max-width: 768px) {
+        display: flex;
+        gap: 16px;
+        padding: 0 24px;
+    }
+`;
+
+const CustomSearchIcon = styled(SearchOutlined)`
+    font-size: 20px;
+    cursor: pointer;
+`;
+
+const CustomFilterIcon = styled(FilterOutlined)`
+    font-size: 20px;
+    cursor: pointer;
+`;
+
+const FilterWrap = styled.div<{ $isFilterOpen: boolean }>`
+    position: fixed;
+    z-index: 50;
+    width: 300px;
+    top: 0;
+    height: 100%;
+    padding: 20px;
+    background-color: white;
+    right: ${({ $isFilterOpen }) => ($isFilterOpen ? "0" : "-100%")};
+    box-shadow: -2px 0 5px rgba(0, 0, 0, 0.2);
+    transition: right 0.3s ease;
+    box-sizing: border-box;
+    overflow-y: auto;
+
+    @media (max-width: 600px) {
+        padding: 20px 30px 20px 20px;
+    }
+`;
+
+const Overlay = styled.div`
+    position: fixed;
+    inset: 0;
+    background-color: rgba(249, 250, 251, 0.7);
+    z-index: 40;
+    backdrop-filter: blur(1px);
+`;
+
+const CancelBtn = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: right;
+    padding: 5px;
+    top: 20px;
+    right: 20px;
+    
+    cursor: pointer;
+`;
+
+const SearchWrap = styled.div<{$isSearchOpen: boolean}>`
+    position: fixed;
+    display: flex;
+    z-index: 50;
+    width: 100%;
+    left: 0;
+    top: ${({ $isSearchOpen }) => ($isSearchOpen ? "0" : "-100%")};
+    height: 80px;
+    padding: 20px;
+    background-color: white;
+    box-shadow: -2px 0 5px rgba(0, 0, 0, 0.2);
+    transition: top 0.3s ease;
+    box-sizing: border-box;
+`;
+
+export {
+    PanelContainer,
+    CustomSearchIcon,
+    CustomFilterIcon,
+    FilterWrap,
+    Overlay,
+    CancelBtn,
+    SearchWrap,
+};

--- a/fe/src/styles/MobileSearchFilterPanelStyle.ts
+++ b/fe/src/styles/MobileSearchFilterPanelStyle.ts
@@ -4,7 +4,7 @@ import { SearchOutlined, FilterOutlined } from "@ant-design/icons";
 const PanelContainer = styled.div`
     display: none;
     padding: 0 16px;
-    @media (max-width: 768px) {
+    @media (max-width: 1000px) {
         display: flex;
         gap: 16px;
         padding: 0 24px;
@@ -34,10 +34,6 @@ const FilterWrap = styled.div<{ $isFilterOpen: boolean }>`
     transition: right 0.3s ease;
     box-sizing: border-box;
     overflow-y: auto;
-
-    @media (max-width: 600px) {
-        padding: 20px 30px 20px 20px;
-    }
 `;
 
 const Overlay = styled.div`
@@ -62,6 +58,7 @@ const CancelBtn = styled.div`
 const SearchWrap = styled.div<{$isSearchOpen: boolean}>`
     position: fixed;
     display: flex;
+    justify-content: center;
     z-index: 50;
     width: 100%;
     left: 0;

--- a/fe/src/styles/NavigationStyle.ts
+++ b/fe/src/styles/NavigationStyle.ts
@@ -3,12 +3,12 @@ import styled from "styled-components";
 const NavContainer = styled.nav`
     width: 100%;
     border-bottom: 1px solid var(--border-color);
-    padding: 1rem;
+    padding: 1.5rem;
     margin-bottom: 4rem;
 `;
 
 const NavWrap = styled.div`
-    max-width: 1000px;
+    max-width: 1075px;
     min-width: 350px;
     margin: auto;
     display: flex;
@@ -23,45 +23,17 @@ const LogoWrap = styled.div`
     flex-direction: column;
     padding: 0px 2px;
     gap: 3px;
+    cursor: pointer;
 `;
 
-const LogoAbbreviation = styled.h1`
-    font-weight: 700;
+const LogoName = styled.h1`
+    font-weight: 800;
     font-size: 24Px;
 `;
-
-const LogoFullName = styled.p`
-    font-weight: 300;
-    font-size: 0.8rem;
-    font-style: italic;
-`;
-
-const InputWrap = styled.div`
-    position: absolute;
-    left: 50%;
-    transform: translate(-50%, 0);
-    border: 1px solid var(--border-color);
-    border-radius: 8px;
-    max-width: 600px;
-    min-width: 300px;
-    margin: 0 20px;
-    display: flex;
-    align-items: center;
-    height: 2.4rem;
-`;
-
-const LoginBtn = styled.div`
-    cursor: pointer;
-    font-size: 0.9rem;
-    margin-right: 2rem;
-`
 
 export {
     NavContainer,
     NavWrap,
-    LogoAbbreviation,
-    LogoFullName,
+    LogoName,
     LogoWrap,
-    InputWrap,
-    LoginBtn
 };

--- a/fe/src/styles/NavigationStyle.ts
+++ b/fe/src/styles/NavigationStyle.ts
@@ -8,6 +8,7 @@ const NavContainer = styled.nav`
 
     @media (max-width: 768px) {
         padding: 1rem 0.5rem;
+        margin-bottom: 1rem;
     }
 `;
 

--- a/fe/src/styles/NavigationStyle.ts
+++ b/fe/src/styles/NavigationStyle.ts
@@ -10,23 +10,26 @@ const NavContainer = styled.nav`
 `;
 
 const NavWrap = styled.div`
-    max-width: 1075px;
+    max-width: 1060px;
     min-width: 350px;
     margin: 1rem auto;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    @media (max-width: 1000px) {
+        width: 780px;
+    }
     @media (max-width: 768px) {
-        margin: 1rem 0.5rem;
+        width: 100%;
+    }
+    @media (max-width: 600px) {
+        width: 363px;
     }
 `;
 
 const LogoWrap = styled.div`
     text-align: center;
-    display: flex;
-    justify-content: space-between;
-    flex-direction: column;
-    padding: 0px 2px;
+    padding-left: 1rem;
     gap: 3px;
     cursor: pointer;
 `;
@@ -37,7 +40,8 @@ const LogoName = styled.h1`
 `;
 
 const SearchWrap = styled.div`
-    @media (max-width: 768px) {
+    margin-right: 30px;
+    @media (max-width: 1000px) {
         display: none;
     }
 `

--- a/fe/src/styles/NavigationStyle.ts
+++ b/fe/src/styles/NavigationStyle.ts
@@ -3,11 +3,8 @@ import styled from "styled-components";
 const NavContainer = styled.nav`
     width: 100%;
     border-bottom: 1px solid var(--border-color);
-    padding: 1rem;
     margin-bottom: 4rem;
-
     @media (max-width: 768px) {
-        padding: 1rem 0.5rem;
         margin-bottom: 1rem;
     }
 `;
@@ -15,10 +12,13 @@ const NavContainer = styled.nav`
 const NavWrap = styled.div`
     max-width: 1075px;
     min-width: 350px;
-    margin: auto;
+    margin: 1rem auto;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    @media (max-width: 768px) {
+        margin: 1rem 0.5rem;
+    }
 `;
 
 const LogoWrap = styled.div`

--- a/fe/src/styles/NavigationStyle.ts
+++ b/fe/src/styles/NavigationStyle.ts
@@ -3,8 +3,12 @@ import styled from "styled-components";
 const NavContainer = styled.nav`
     width: 100%;
     border-bottom: 1px solid var(--border-color);
-    padding: 1.5rem;
+    padding: 1rem;
     margin-bottom: 4rem;
+
+    @media (max-width: 768px) {
+        padding: 1rem 0.5rem;
+    }
 `;
 
 const NavWrap = styled.div`
@@ -31,9 +35,16 @@ const LogoName = styled.h1`
     font-size: 24Px;
 `;
 
+const SearchWrap = styled.div`
+    @media (max-width: 768px) {
+        display: none;
+    }
+`
+
 export {
     NavContainer,
     NavWrap,
     LogoName,
     LogoWrap,
+    SearchWrap,
 };

--- a/fe/src/styles/SearchInputStyle.ts
+++ b/fe/src/styles/SearchInputStyle.ts
@@ -1,5 +1,20 @@
 import styled from "styled-components";
 
+const InputWrap = styled.div`
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    max-width: 600px;
+    min-width: 300px;
+    margin: 0 50px 0 0;
+    display: flex;
+    align-items: center;
+    height: 2.4rem;
+
+    @media (max-width: 768px) {
+        display: none;
+    }
+`;
+
 const InputField = styled.input`
     width: 300px;
     height: 100%;
@@ -20,7 +35,6 @@ const SearchField = styled.button`
     justify-content: center;
     cursor: pointer;
     background-color: white;
-    
 `;
 
-export { InputField, SearchField };
+export { InputWrap, InputField, SearchField };

--- a/fe/src/styles/SearchInputStyle.ts
+++ b/fe/src/styles/SearchInputStyle.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 const InputWrap = styled.div`
     border: 1px solid var(--border-color);
     border-radius: 8px;
-    max-width: 600px;
+    max-width: 450px;
     min-width: 300px;
     margin: 0 50px 0 0;
     display: flex;
@@ -11,7 +11,7 @@ const InputWrap = styled.div`
     height: 2.4rem;
 
     @media (max-width: 768px) {
-        display: none;
+        margin: auto;
     }
 `;
 

--- a/fe/src/styles/SearchInputStyle.ts
+++ b/fe/src/styles/SearchInputStyle.ts
@@ -5,7 +5,6 @@ const InputWrap = styled.div`
     border-radius: 8px;
     max-width: 450px;
     min-width: 300px;
-    margin: 0 50px 0 0;
     display: flex;
     align-items: center;
     height: 2.4rem;
@@ -21,6 +20,10 @@ const InputField = styled.input`
     padding: 0 10px;
     outline: none;
     border: none;
+
+    @media (max-width: 450px) {
+        width: 200px;
+    }
 `;
 
 const SearchField = styled.button`

--- a/fe/src/tests/componentsTests/Navgation.test.tsx
+++ b/fe/src/tests/componentsTests/Navgation.test.tsx
@@ -2,14 +2,19 @@ import { render } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import Navigation from "@/components/Navigation/Navigation";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 describe("Layout Navigation Component 테스트", () => {
     test("Navigation Component가 렌더링 되었을때 MYB 로고가 보인다.", () => {
         const { getByText } = render(
             <MemoryRouter>
-                <Navigation />
+                <QueryClientProvider client={queryClient}>
+                    <Navigation />
+                </QueryClientProvider>
             </MemoryRouter>
         );
-        expect(getByText("MYB")).toBeInTheDocument();
+        expect(getByText("Meet Your Book")).toBeInTheDocument();
     });
 });

--- a/fe/src/tests/pagesTests/Layout.test.tsx
+++ b/fe/src/tests/pagesTests/Layout.test.tsx
@@ -1,15 +1,23 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Layout from "@/pages/Layout";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 test("Navigation이 렌더링 되었을때 Outlet이 렌더링 되는지 확인", () => {
     render(
         <MemoryRouter initialEntries={["/test"]}>
-            <Routes>
-                <Route path="/" element={<Layout />}>
-                    <Route path="test" element={<div>Test Component</div>} />
-                </Route>
-            </Routes>
+            <QueryClientProvider client={queryClient}>
+                <Routes>
+                    <Route path="/" element={<Layout />}>
+                        <Route
+                            path="test"
+                            element={<div>Test Component</div>}
+                        />
+                    </Route>
+                </Routes>
+            </QueryClientProvider>
         </MemoryRouter>
     );
 


### PR DESCRIPTION
## 변경 사항
- width가 768px 이하일때 인풋 display: none이 되도록 수정
- filter, search 아이콘이 생기고 클릭하면 해당 컴포넌트가 사이드바로 나오도록 구현
- 1024px 이하일때 홈화면의 필터 창 display: none 적용
- 600px이하 === 모바일 화면 일때 책을 4 -> 2개씩 보여주도록 수정
- 로그인, 회원가입 페이지 메인 로고 추가
- 메인 로고 클릭시 홈으로 이동 구현

## 관련 이슈
#55

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [ ] 버그 수정
- [X] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [X] 리팩토링
- [ ] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)
- 모바일 화면

![모바일반응형구현](https://github.com/user-attachments/assets/aff68c49-61fc-4cd4-a0c5-8ca9709268b1)

- 로그인
<img width="645" alt="스크린샷 2024-08-22 오후 3 44 02" src="https://github.com/user-attachments/assets/de979c6c-9d8a-4e75-a9ad-bc14c4212928">

- 회원가입
<img width="645" alt="스크린샷 2024-08-22 오후 3 44 06" src="https://github.com/user-attachments/assets/983f67b9-73b2-4b7a-b17c-8a047e727cd3">
