### PR TITLE
[BE] BookLibrary 데이터가 중복해서 저장되는 문제 해결

### DIFF
--- a/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/crawler/BookPageConcurrencyTest.java
+++ b/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/crawler/BookPageConcurrencyTest.java
@@ -82,7 +82,7 @@ class BookPageConcurrencyTest {
             String expectedUrl = "http://test" + i + ".com";
 
             long count = capturedBookInfos.stream()
-                .filter(bookInfo -> bookInfo.getBaseUrl().equals(expectedUrl))
+                .filter(bookInfo -> bookInfo.baseUrl().equals(expectedUrl))
                 .count();
 
             assertThat(count).isEqualTo(1);

--- a/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/crawler/BookPageProcessorTest.java
+++ b/be/ebook-search/ebook-crawler/src/test/java/com/meetyourbook/crawler/BookPageProcessorTest.java
@@ -95,12 +95,12 @@ class BookPageProcessorTest {
         List<BookInfo> capturedBookInfos = bookInfosCaptor.getValue();
         assertThat(1).isEqualTo(capturedBookInfos.size());
         BookInfo bookInfo = capturedBookInfos.getFirst();
-        assertThat(bookInfo.getTitle()).isEqualTo("테스트 책 제목");
-        assertThat(bookInfo.getAuthor()).isEqualTo("제이든");
-        assertThat(bookInfo.getPublisher()).isEqualTo("테스트 출판사");
-        assertThat(bookInfo.getImageUrl()).isEqualTo("example.com/book-cover.jpg");
-        assertThat(bookInfo.getPublishDate()).isEqualTo(LocalDate.of(2024, 1, 1));
-        assertThat(bookInfo.getBaseUrl()).isEqualTo("https://example.com");
+        assertThat(bookInfo.title()).isEqualTo("테스트 책 제목");
+        assertThat(bookInfo.author()).isEqualTo("제이든");
+        assertThat(bookInfo.publisher()).isEqualTo("테스트 출판사");
+        assertThat(bookInfo.imageUrl()).isEqualTo("example.com/book-cover.jpg");
+        assertThat(bookInfo.publishDate()).isEqualTo(LocalDate.of(2024, 1, 1));
+        assertThat(bookInfo.baseUrl()).isEqualTo("https://example.com");
 
         verify(booksCounter).increment(1);
         verify(pagesCounter).increment();
@@ -154,7 +154,7 @@ class BookPageProcessorTest {
         List<BookInfo> capturedBookInfos = bookInfosCaptor.getValue();
         assertThat(1).isEqualTo(capturedBookInfos.size());
         BookInfo bookInfo = capturedBookInfos.getFirst();
-        assertThat(bookInfo.getPublishDate()).isNull();
+        assertThat(bookInfo.publishDate()).isNull();
     }
 
     @Test
@@ -219,7 +219,7 @@ class BookPageProcessorTest {
         verify(bookQueueService).addBookInfosToQueue(bookInfosCaptor.capture());
         List<BookInfo> capturedBookInfos = bookInfosCaptor.getValue();
         BookInfo bookInfo = capturedBookInfos.getFirst();
-        assertThat(bookInfo.getBookUrl()).isEqualTo(expectedBookUrl);
+        assertThat(bookInfo.bookUrl()).isEqualTo(expectedBookUrl);
     }
 
 

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/config/JpaConfig.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.meetyourbook.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/dto/BookInfo.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/dto/BookInfo.java
@@ -3,44 +3,31 @@ package com.meetyourbook.dto;
 import com.meetyourbook.entity.Book;
 import java.time.LocalDate;
 import lombok.Builder;
-import lombok.Value;
 
-@Value
 @Builder
-public class BookInfo {
+public record BookInfo(
 
-    String provider;
-    String title;
-    String author;
-    String publisher;
-    LocalDate publishDate;
-    String imageUrl;
-    String description;
-    String baseUrl;
-    String bookUrl;
+    String title,
+    String author,
+    String publisher,
+    LocalDate publishDate,
+    String provider,
+    String imageUrl,
+    String description,
+    String baseUrl,
+    String bookUrl
 
-    @Override
-    public String toString() {
-        return "BookInfo{" +
-            "provider='" + provider + '\'' +
-            ", title='" + title + '\'' +
-            ", author='" + author + '\'' +
-            ", publisher='" + publisher + '\'' +
-            ", publishDate=" + publishDate +
-            ", imageUrl='" + imageUrl + '\'' +
-            ", description='" + description + '\'' +
-            ", baseUrl='" + baseUrl + '\'' +
-            '}';
-    }
+) {
 
     public Book toEntity() {
         return Book.builder()
             .title(title)
             .author(author)
             .publisher(publisher)
-            .imageUrl(imageUrl)
             .publishDate(publishDate)
             .provider(provider)
+            .imageUrl(imageUrl)
             .build();
     }
+
 }

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/BaseEntity.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.meetyourbook.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/Book.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/Book.java
@@ -23,7 +23,7 @@ import org.hibernate.annotations.UuidGenerator.Style;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Book {
+public class Book extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/BookLibrary.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/BookLibrary.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
-public class BookLibrary {
+public class BookLibrary extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/BookLibrary.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/BookLibrary.java
@@ -45,6 +45,10 @@ public class BookLibrary extends BaseEntity {
         return bookLibrary;
     }
 
+    public void updateUrl(String url) {
+        this.url = url;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/Library.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/entity/Library.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Library {
+public class Library extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/repository/BookLibraryRepository.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/repository/BookLibraryRepository.java
@@ -2,6 +2,8 @@ package com.meetyourbook.repository;
 
 import com.meetyourbook.entity.BookLibrary;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -16,5 +18,7 @@ public interface BookLibraryRepository extends JpaRepository<BookLibrary, Long> 
 
         Integer getBookCount();
     }
+
+    Optional<BookLibrary> findBookLibraryByBookIdAndLibraryId(UUID bookId, Long libraryId);
 
 }

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/service/BookLibraryService.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/service/BookLibraryService.java
@@ -34,9 +34,17 @@ public class BookLibraryService {
         for (BookInfo bookInfo : bookInfos) {
             Book book = getBook(bookInfo);
             Library library = getLibrary(bookInfo);
-            BookLibrary bookLibrary = BookLibrary.createBookLibrary(book, library,
-                bookInfo.getBookUrl());
-            bookLibraries.add(bookLibrary);
+            Optional<BookLibrary> existingBookLibrary = bookLibraryRepository.findBookLibraryByBookIdAndLibraryId(
+                book.getId(), library.getId());
+            if (existingBookLibrary.isPresent()) {
+                BookLibrary bookLibrary = existingBookLibrary.get();
+                bookLibrary.updateUrl(bookInfo.bookUrl());
+            }
+            if (existingBookLibrary.isEmpty()) {
+                BookLibrary bookLibrary = BookLibrary.createBookLibrary(book, library,
+                    bookInfo.bookUrl());
+                bookLibraries.add(bookLibrary);
+            }
         }
         bookLibraryRepository.saveAll(bookLibraries);
     }
@@ -47,14 +55,14 @@ public class BookLibraryService {
     }
 
     private Library getLibrary(BookInfo bookInfo) {
-        return libraryCache.computeIfAbsent(bookInfo.getBaseUrl(),
+        return libraryCache.computeIfAbsent(bookInfo.baseUrl(),
             libraryDomainService::findByBaseUrl);
     }
 
     private Optional<Book> findBookByBookInfo(BookInfo bookInfo) {
         return bookRepository.findFirstByBookInfo(
-            bookInfo.getTitle(), bookInfo.getAuthor(), bookInfo.getPublisher(),
-            bookInfo.getPublishDate());
+            bookInfo.title(), bookInfo.author(), bookInfo.publisher(),
+            bookInfo.publishDate());
     }
 
 }

--- a/be/ebook-search/ebook-domain/src/test/java/com/meetyourbook/common/config/TestJpaConfig.java
+++ b/be/ebook-search/ebook-domain/src/test/java/com/meetyourbook/common/config/TestJpaConfig.java
@@ -5,6 +5,7 @@ import java.util.Properties;
 import javax.sql.DataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.orm.jpa.JpaTransactionManager;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @Configuration
 @EnableJpaRepositories(basePackages = "com.meetyourbook.repository")
 @EnableTransactionManagement
+@EnableJpaAuditing
 public class TestJpaConfig {
 
     @Bean

--- a/be/ebook-search/ebook-domain/src/test/java/com/meetyourbook/service/BookLibraryServiceTest.java
+++ b/be/ebook-search/ebook-domain/src/test/java/com/meetyourbook/service/BookLibraryServiceTest.java
@@ -1,0 +1,171 @@
+package com.meetyourbook.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.meetyourbook.dto.BookInfo;
+import com.meetyourbook.entity.Book;
+import com.meetyourbook.entity.BookLibrary;
+import com.meetyourbook.entity.Library;
+import com.meetyourbook.repository.BookLibraryRepository;
+import com.meetyourbook.repository.BookRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookLibraryServiceTest {
+
+    @Mock
+    private LibraryDomainService libraryDomainService;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private BookLibraryRepository bookLibraryRepository;
+
+    @InjectMocks
+    private BookLibraryService bookLibraryService;
+
+    private BookInfo bookInfo1;
+    private BookInfo bookInfo2;
+    private Book book1;
+    private Book book2;
+    private Library library;
+
+    @BeforeEach
+    void setUp() {
+        bookInfo1 = BookInfo.builder()
+            .title("Title1")
+            .author("Author1")
+            .publisher("Publisher1")
+            .publishDate(LocalDate.of(2021, 1, 1))
+            .bookUrl("http://library.com/book1")
+            .baseUrl("http://library.com")
+            .build();
+        bookInfo2 = BookInfo.builder()
+            .title("Title2")
+            .author("Author2")
+            .publisher("Publisher2")
+            .publishDate(LocalDate.of(2022, 2, 2))
+            .bookUrl("http://library.com/book2")
+            .baseUrl("http://library.com")
+            .build();
+
+        book1 = Book.builder()
+            .title("Title1")
+            .author("Author1")
+            .publisher("Publisher1")
+            .publishDate(LocalDate.of(2021, 1, 1))
+            .build();
+
+        book2 = Book.builder()
+            .title("Title2")
+            .author("Author2")
+            .publisher("Publisher2")
+            .publishDate(LocalDate.of(2022, 2, 2))
+            .build();
+
+        library = Library.builder()
+            .name("Library")
+            .libraryUrl("http://library.com")
+            .build();
+    }
+
+    @Test
+    @DisplayName("책 정보 2개가 새로운 데이터일 때 모두 저장한다.")
+    void saveAll_WithNewBooks_ShouldSaveNewBooksAndBookLibraries() {
+        // Given
+        when(bookRepository.findFirstByBookInfo(anyString(), anyString(), anyString(), any(
+            LocalDate.class)))
+            .thenReturn(Optional.empty());
+        when(bookRepository.save(any(Book.class))).thenReturn(book1).thenReturn(book2);
+        when(libraryDomainService.findByBaseUrl(anyString())).thenReturn(library);
+        when(bookLibraryRepository.findBookLibraryByBookIdAndLibraryId(any(), any()))
+            .thenReturn(Optional.empty());
+
+        // When
+        bookLibraryService.saveAll(List.of(bookInfo1, bookInfo2));
+
+        // Then
+        verify(bookRepository, times(2)).save(any(Book.class));
+        verify(bookLibraryRepository).saveAll(argThat(bookLibraries -> {
+            List<BookLibrary> bookLibraryList = StreamSupport.stream(bookLibraries.spliterator(),
+                    false)
+                .toList();
+
+            return bookLibraryList.size() == 2 &&
+                bookLibraryList.stream()
+                    .anyMatch(bl -> bl.getBook().getTitle().equals(book1.getTitle())) &&
+                bookLibraryList.stream()
+                    .anyMatch(bl -> bl.getBook().getTitle().equals(book2.getTitle())) &&
+                bookLibraryList.stream().allMatch(bl -> bl.getLibrary().equals(library));
+        }));
+    }
+
+    @Test
+    @DisplayName("책 정보 2개가 이미 존재하는 데이터일 때 책 상세 url만 업데이트한다.")
+    void saveAll_WithExistingBooks_ShouldUpdateBookUrl() {
+        // Given
+        when(bookRepository.findFirstByBookInfo(anyString(), anyString(), anyString(), any(
+            LocalDate.class)))
+            .thenReturn(Optional.of(book1)).thenReturn(Optional.of(book2));
+        when(libraryDomainService.findByBaseUrl(anyString())).thenReturn(library);
+        BookLibrary bookLibrary1 = new BookLibrary(book1, library, "http://library.com/oldbook1");
+        BookLibrary bookLibrary2 = new BookLibrary(book2, library, "http://library.com/oldbook2");
+        when(bookLibraryRepository.findBookLibraryByBookIdAndLibraryId(any(), any()))
+            .thenReturn(Optional.of(bookLibrary1)).thenReturn(Optional.of(bookLibrary2));
+        // When
+        bookLibraryService.saveAll(List.of(bookInfo1, bookInfo2));
+
+        // Then
+        verify(bookRepository, never()).save(any(Book.class));
+        assertThat(bookLibrary1.getUrl()).isEqualTo(bookInfo1.bookUrl());
+        assertThat(bookLibrary2.getUrl()).isEqualTo(bookInfo2.bookUrl());
+
+    }
+
+    @Test
+    @DisplayName("책 정보 2개 중 1개만 새로운 데이터일 때 1개만 저장한다. 나머지는 url만 업데이트한다.")
+    void saveAll_WithOneNewBook_ShouldSaveOneBookAndUpdateAnotherBook() {
+        // Given
+        when(bookRepository.findFirstByBookInfo(anyString(), anyString(), anyString(), any(
+            LocalDate.class)))
+            .thenReturn(Optional.of(book1)).thenReturn(Optional.empty());
+        when(bookRepository.save(any(Book.class))).thenReturn(book2);
+        when(libraryDomainService.findByBaseUrl(anyString())).thenReturn(library);
+        BookLibrary bookLibrary1 = new BookLibrary(book1, library, "http://library.com/oldbook1");
+        when(bookLibraryRepository.findBookLibraryByBookIdAndLibraryId(any(), any()))
+            .thenReturn(Optional.of(bookLibrary1)).thenReturn(Optional.empty());
+
+        // When
+        bookLibraryService.saveAll(List.of(bookInfo1, bookInfo2));
+
+        // Then
+        verify(bookRepository, times(1)).save(any(Book.class));
+        verify(bookLibraryRepository).saveAll(argThat(bookLibraries -> {
+            List<BookLibrary> bookLibraryList = StreamSupport.stream(bookLibraries.spliterator(),
+                    false)
+                .toList();
+
+            return bookLibraryList.size() == 1 && bookLibraryList.stream()
+                .anyMatch(bl -> bl.getBook().getTitle().equals(book2.getTitle()));
+        }));
+        assertThat(bookLibrary1.getUrl()).isEqualTo(bookInfo1.bookUrl());
+    }
+}


### PR DESCRIPTION
## 변경 사항
- BookLibrary 테이블에서 bookId와 libraryId 쌍이 존재하는 경우 bookUrl만 update 하고 그렇지 않으면 save를 해서 레코드를 추가합니다.

## 관련 이슈
#59

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [x] 버그 수정
- [ ] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)
x

## 추가 설명
x