### PR TITLE
[FE] 책 상세 팝업 기능 구현

### DIFF
--- a/fe/src/components/BookInfoModal/BookInfoModal.tsx
+++ b/fe/src/components/BookInfoModal/BookInfoModal.tsx
@@ -1,17 +1,22 @@
 import { BookContent } from "@/types/Books";
 import * as S from "@/styles/BookInfoModalStyle";
 import LibrariesPaging from "./LibrariesPaging";
+import { useRef } from "react";
+import useOnClickOutside from "@/hooks/useOnClickOutside";
 interface BookInfoModalProps {
     bookData: BookContent;
     handleModalClose: () => void;
 }
 
 const BookInfoModal = ({ bookData, handleModalClose }: BookInfoModalProps) => {
+    const inSideRef = useRef(null)
     const { imageUrl, title, author, provider, publisher, libraryResponses } = bookData;
-    console.log(libraryResponses)
+
+    useOnClickOutside(inSideRef, handleModalClose)
+    
     return (
         <S.PopupOverlay>
-            <S.PopupCard>
+            <S.PopupCard ref={inSideRef}>
                 <S.CloseBtn onClick={handleModalClose} />
                 <S.BookInfoWrap>
                     <S.Img src={`http://${imageUrl}`} alt={title} />

--- a/fe/src/components/BookInfoModal/BookInfoModal.tsx
+++ b/fe/src/components/BookInfoModal/BookInfoModal.tsx
@@ -1,0 +1,32 @@
+import { BookContent } from "@/types/Books";
+import * as S from "@/styles/BookInfoModalStyle";
+import LibrariesPaging from "./LibrariesPaging";
+interface BookInfoModalProps {
+    bookData: BookContent;
+    handleModalClose: () => void;
+}
+
+const BookInfoModal = ({ bookData, handleModalClose }: BookInfoModalProps) => {
+    const { imageUrl, title, author, provider, publisher, libraryResponses } = bookData;
+    console.log(libraryResponses)
+    return (
+        <S.PopupOverlay>
+            <S.PopupCard>
+                <S.CloseBtn onClick={handleModalClose} />
+                <S.BookInfoWrap>
+                    <S.Img src={`http://${imageUrl}`} alt={title} />
+                    <S.InfoWrap>
+                        <S.Title>{title}</S.Title>
+                        <S.MetaInfo>저자: {author}</S.MetaInfo>
+                        <S.MetaInfo>제공: {provider}</S.MetaInfo>
+                        <S.MetaInfo>출판사: {publisher}</S.MetaInfo>
+                    </S.InfoWrap>
+                </S.BookInfoWrap>
+                <S.Description>디스크립션 태그입니다.</S.Description>
+                <LibrariesPaging libraryResponses={libraryResponses}/>
+            </S.PopupCard>
+        </S.PopupOverlay>
+    );
+};
+
+export default BookInfoModal;

--- a/fe/src/components/BookInfoModal/LibrariesPaging.tsx
+++ b/fe/src/components/BookInfoModal/LibrariesPaging.tsx
@@ -1,6 +1,6 @@
 import { LibrariesResponseType } from "@/types/LibrariesResponse";
 import * as S from "@/styles/LibrariesPagingStyle";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import useDebounce from "@/hooks/useDebounce";
 import { DEBOUNCE_TIME, PAGINATION_FIRST_PAGE } from "@/constants";
 import { Pagination } from "antd";
@@ -32,6 +32,9 @@ const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
     );
 
     const handlePageChange = (page: number) => setCurrentPage(page);
+
+    useEffect(() => setCurrentPage(PAGINATION_FIRST_PAGE), [filteredLibraries]);
+    
     return (
         <S.Container>
             <p>소장 도서관: {libraryResponses.length}</p>

--- a/fe/src/components/BookInfoModal/LibrariesPaging.tsx
+++ b/fe/src/components/BookInfoModal/LibrariesPaging.tsx
@@ -2,21 +2,36 @@ import { LibrariesType } from "@/types/Libraries";
 import * as S from "@/styles/LibrariesPagingStyle";
 import { useMemo, useState } from "react";
 import useDebounce from "@/hooks/useDebounce";
-import { DEBOUNCE_TIME } from "@/constants";
+import { DEBOUNCE_TIME, PAGINATION_FIRST_PAGE } from "@/constants";
+import { Pagination } from "antd";
+import { LIBRARIES_PER_PAGE } from "@/types/PageNation";
+
 interface LibrariesPagingProps {
     libraryResponses: LibrariesType[];
 }
+
 const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
     const [searchValue, setSearchValue] = useState("");
+    const [currentPage, setCurrentPage] = useState(PAGINATION_FIRST_PAGE);
 
     const debouncedValue = useDebounce(searchValue, DEBOUNCE_TIME);
-    
+
     const filteredLibraries = useMemo(() => {
         return debouncedValue
-        ? libraryResponses.filter((item: LibrariesType) => item.LibraryName.includes(debouncedValue))
-        : libraryResponses;
+            ? libraryResponses.filter((item: LibrariesType) =>
+                  item.LibraryName.includes(debouncedValue)
+              )
+            : libraryResponses;
     }, [debouncedValue, libraryResponses]);
 
+    const indexOfLast = currentPage * LIBRARIES_PER_PAGE;
+    const indexOfFirst = indexOfLast - LIBRARIES_PER_PAGE;
+    const currentPageLibraries = filteredLibraries.slice(
+        indexOfFirst,
+        indexOfLast
+    );
+
+    const handlePageChange = (page: number) => setCurrentPage(page);
     return (
         <S.Container>
             <p>소장 도서관: {libraryResponses.length}</p>
@@ -26,12 +41,21 @@ const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
                 onChange={(e) => setSearchValue(e.target.value)}
             />
             <S.LibrariesWrap>
-                {filteredLibraries.map((curLibrary, idx) => (
-                    <S.LibraryItem key={idx}>
+                {currentPageLibraries.map((curLibrary, idx) => (
+                    <S.LibraryItem key={idx} href={curLibrary.BookLibraryUrl}>
                         {curLibrary.LibraryName}
                     </S.LibraryItem>
                 ))}
             </S.LibrariesWrap>
+            <S.PagingWrap>
+                <Pagination
+                    current={currentPage}
+                    total={filteredLibraries.length}
+                    pageSize={LIBRARIES_PER_PAGE}
+                    onChange={handlePageChange}
+                    size="small"
+                />
+            </S.PagingWrap>
         </S.Container>
     );
 };

--- a/fe/src/components/BookInfoModal/LibrariesPaging.tsx
+++ b/fe/src/components/BookInfoModal/LibrariesPaging.tsx
@@ -1,4 +1,4 @@
-import { LibrariesType } from "@/types/Libraries";
+import { LibrariesResponseType } from "@/types/LibrariesResponse";
 import * as S from "@/styles/LibrariesPagingStyle";
 import { useMemo, useState } from "react";
 import useDebounce from "@/hooks/useDebounce";
@@ -7,7 +7,7 @@ import { Pagination } from "antd";
 import { LIBRARIES_PER_PAGE } from "@/types/PageNation";
 
 interface LibrariesPagingProps {
-    libraryResponses: LibrariesType[];
+    libraryResponses: LibrariesResponseType[];
 }
 
 const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
@@ -18,7 +18,7 @@ const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
 
     const filteredLibraries = useMemo(() => {
         return debouncedValue
-            ? libraryResponses.filter((item: LibrariesType) =>
+            ? libraryResponses.filter((item: LibrariesResponseType) =>
                   item.LibraryName.includes(debouncedValue)
               )
             : libraryResponses;

--- a/fe/src/components/BookInfoModal/LibrariesPaging.tsx
+++ b/fe/src/components/BookInfoModal/LibrariesPaging.tsx
@@ -1,16 +1,35 @@
 import { LibrariesType } from "@/types/Libraries";
 import * as S from "@/styles/LibrariesPagingStyle";
+import { useMemo, useState } from "react";
+import useDebounce from "@/hooks/useDebounce";
+import { DEBOUNCE_TIME } from "@/constants";
 interface LibrariesPagingProps {
     libraryResponses: LibrariesType[];
 }
 const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
+    const [searchValue, setSearchValue] = useState("");
+
+    const debouncedValue = useDebounce(searchValue, DEBOUNCE_TIME);
+    
+    const filteredLibraries = useMemo(() => {
+        return debouncedValue
+        ? libraryResponses.filter((item: LibrariesType) => item.LibraryName.includes(debouncedValue))
+        : libraryResponses;
+    }, [debouncedValue, libraryResponses]);
+
     return (
         <S.Container>
             <p>소장 도서관: {libraryResponses.length}</p>
-            <S.Input placeholder="도서관 검색..." />
+            <S.Input
+                value={searchValue}
+                placeholder="도서관 검색..."
+                onChange={(e) => setSearchValue(e.target.value)}
+            />
             <S.LibrariesWrap>
-                {libraryResponses.map((curLibrary, idx) => (
-                    <S.LibraryItem key={idx}>{curLibrary.LibraryName}</S.LibraryItem>
+                {filteredLibraries.map((curLibrary, idx) => (
+                    <S.LibraryItem key={idx}>
+                        {curLibrary.LibraryName}
+                    </S.LibraryItem>
                 ))}
             </S.LibrariesWrap>
         </S.Container>

--- a/fe/src/components/BookInfoModal/LibrariesPaging.tsx
+++ b/fe/src/components/BookInfoModal/LibrariesPaging.tsx
@@ -1,0 +1,20 @@
+import { LibrariesType } from "@/types/Libraries";
+import * as S from "@/styles/LibrariesPagingStyle";
+interface LibrariesPagingProps {
+    libraryResponses: LibrariesType[];
+}
+const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
+    return (
+        <S.Container>
+            <p>소장 도서관: {libraryResponses.length}</p>
+            <S.Input placeholder="도서관 검색..." />
+            <S.LibrariesWrap>
+                {libraryResponses.map((curLibrary, idx) => (
+                    <S.LibraryItem key={idx}>{curLibrary.LibraryName}</S.LibraryItem>
+                ))}
+            </S.LibrariesWrap>
+        </S.Container>
+    );
+};
+
+export default LibrariesPaging;

--- a/fe/src/components/BooksDisplay/BookCard/BookCard.tsx
+++ b/fe/src/components/BooksDisplay/BookCard/BookCard.tsx
@@ -3,6 +3,7 @@ import { ViewType } from "@/types/View";
 import { BookContent } from "@/types/Books";
 import * as S from "@/styles/BookCardStyle";
 import { ANIMATION_TIME } from "@/constants";
+import BookInfoModal from "@/components/BookInfoModal/BookInfoModal";
 interface BookItemProps {
     bookData: BookContent;
     viewMode: ViewType;
@@ -11,6 +12,11 @@ interface BookItemProps {
 const BookCard = ({ bookData, viewMode }: BookItemProps) => {
     const { imageUrl, title, author, provider, publisher } = bookData;
     const [isVisible, setIsVisible] = useState(false);
+    const [isModalOpen, setModalOpen] = useState(false)
+
+    const handleModalOpen = () => setModalOpen(true)
+
+    const handleModalClose = () => setModalOpen(false)
 
     useEffect(() => {
         const timer = setTimeout(() => setIsVisible(true), ANIMATION_TIME);
@@ -25,7 +31,7 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
     return (
         <>
             {viewMode === "grid" ? (
-                <S.GridCard $isVisible={isVisible}>
+                <S.GridCard $isVisible={isVisible} onClick={handleModalOpen}>
                     <S.Image
                         src={`http://${imageUrl}`}
                         alt={title}
@@ -38,13 +44,13 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
                     </S.TextContainer>
                 </S.GridCard>
             ) : (
-                <S.ListCard $isVisible={isVisible}>
+                <S.ListCard $isVisible={isVisible} onClick={handleModalOpen}>
                     <S.Image
                         src={`http://${imageUrl}`}
                         alt={title}
                         onError={handleImageError}
                     />
-                    <S.TextContainer $viewMode="list">
+                    <S.TextContainer $viewMode="list" >
                         <S.Title>{title}</S.Title>
                         <S.Subtitle>{author}</S.Subtitle>
                         <div>
@@ -54,6 +60,7 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
                     </S.TextContainer>
                 </S.ListCard>
             )}
+            {isModalOpen && <BookInfoModal bookData={bookData} handleModalClose={handleModalClose}/>}
         </>
     );
 };

--- a/fe/src/components/FilterDisplay/LibraryFilter/LibraryFilter.tsx
+++ b/fe/src/components/FilterDisplay/LibraryFilter/LibraryFilter.tsx
@@ -9,7 +9,6 @@ import useQueryData from "@/hooks/useQueryData";
 import LibraryList from "./LibraryList";
 import LoadingFallBack from "@/components/LodingFallBack/LoadingFallBack";
 
-
 const LibraryFilter = () => {
     const {
         isOpen,
@@ -25,7 +24,7 @@ const LibraryFilter = () => {
     
     const libraries = useMemo(() => {
         return debouncedValue
-        ? data.filter((item: LibrariesType) => item.LibraryName.includes(debouncedValue))
+        ? data.filter((item: LibrariesType) => item.name.includes(debouncedValue))
         : data;
     }, [debouncedValue, data]);
 

--- a/fe/src/components/FilterDisplay/LibraryFilter/LibraryFilter.tsx
+++ b/fe/src/components/FilterDisplay/LibraryFilter/LibraryFilter.tsx
@@ -25,7 +25,7 @@ const LibraryFilter = () => {
     
     const libraries = useMemo(() => {
         return debouncedValue
-        ? data.filter((item: LibrariesType) => item.name.includes(debouncedValue))
+        ? data.filter((item: LibrariesType) => item.LibraryName.includes(debouncedValue))
         : data;
     }, [debouncedValue, data]);
 

--- a/fe/src/components/FilterDisplay/LibraryFilter/LibraryList.tsx
+++ b/fe/src/components/FilterDisplay/LibraryFilter/LibraryList.tsx
@@ -1,15 +1,16 @@
 import React from "react";
-import { LibrariesType } from "@/types/Libraries";
 import * as S from "@/styles/LibraryListStyle"
 
+type Libraries = {id: string, name: string}
 interface LibraryListProps {
-    libraries: LibrariesType[];
+    libraries: Libraries[];
     librariesFilter: string[];
     handleSelectLibrary: (id: string) => void;
 }
 
 const LibraryList = React.memo(
     ({ libraries, librariesFilter, handleSelectLibrary }: LibraryListProps) => (
+        
         <>
             {libraries.map((library, index) => (
                 <S.ListItem key={library.id}>

--- a/fe/src/constants/index.ts
+++ b/fe/src/constants/index.ts
@@ -4,7 +4,7 @@ export const DROP_DOWN_INITIAL_ITEMS = [
     { value: "author", label: "저자" },
     { value: "publisher", label: "출판사" },
 ];
-
+export const PAGINATION_FIRST_PAGE = 1
 export const FIRST_PAGE = 0;
 export const ANIMATION_TIME = 100;
 

--- a/fe/src/hooks/useOnClickOutside.tsx
+++ b/fe/src/hooks/useOnClickOutside.tsx
@@ -1,0 +1,24 @@
+import { useEffect, RefObject } from "react";
+
+const useOnClickOutside = <T extends HTMLElement>(
+    ref: RefObject<T>,
+    handler: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+    useEffect(() => {
+        const listener = (event: MouseEvent) => {
+            if (!ref.current || ref.current.contains(event.target as Node)) {
+                return;
+            }
+
+            handler(false);
+        };
+
+        document.addEventListener("mousedown", listener);
+
+        return () => {
+            document.removeEventListener("mousedown", listener);
+        };
+    }, [ref, handler]);
+};
+
+export default useOnClickOutside;

--- a/fe/src/services/fetch.ts
+++ b/fe/src/services/fetch.ts
@@ -2,7 +2,7 @@ const API_URL = import.meta.env.VITE_API_URL
 
 export const fetchAPI = async (query: string, option: RequestInit) => {
     try{
-        const response = await fetch(API_URL+ 11+ query, option)
+        const response = await fetch(API_URL + query, option)
 
         if(!response.ok) {
             throw new Error(`${response.status}`)

--- a/fe/src/styles/BookCardStyle.ts
+++ b/fe/src/styles/BookCardStyle.ts
@@ -8,6 +8,7 @@ const Card = styled.div<{ $isVisible: boolean }>`
     padding: 0.3rem;
     margin: 0 auto;
     box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.05);
+    cursor: pointer;
     transition:
         opacity 0.2s ease-in-out,
         box-shadow 0.2s ease-in-out,

--- a/fe/src/styles/BookInfoModalStyle.ts
+++ b/fe/src/styles/BookInfoModalStyle.ts
@@ -1,75 +1,91 @@
 import styled, { keyframes } from "styled-components";
 import { CloseOutlined } from "@ant-design/icons";
 
-const modalShow = keyframes`
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
+const fadeIn = keyframes`
+    from { opacity: 0; transform: scale(0.95); }
+    to { opacity: 1; transform: scale(1); }
 `;
+
 const PopupOverlay = styled.div`
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(249, 250, 251, 0.7);
+    background: rgba(0, 0, 0, 0.5);
     display: flex;
     justify-content: center;
     align-items: center;
     z-index: 1000;
-    animation: ${modalShow} 0.2s ease-in-out forwards;
 `;
 
 const PopupCard = styled.div`
     background-color: #ffffff;
-    border-radius: 12px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    padding: 16px;
-    max-width: 42rem;
-    min-width: 300px;
+    border-radius: 16px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+    padding: 24px;
+    max-width: 450px;
+    width: 90%;
+    animation: ${fadeIn} 0.3s ease-out forwards;
+
+    @media (max-width: 600px) {
+        width: 300px;
+    }
 `;
 
 const CloseBtn = styled(CloseOutlined)`
-    display: block;
-    text-align: right;
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    font-size: 20px;
+    color: #666;
+    cursor: pointer;
+    transition: color 0.2s;
+
+    &:hover {
+        color: #000;
+    }
 `;
 
 const BookInfoWrap = styled.div`
-    width: 100%;
     display: flex;
-    gap: 1.5rem;
+    gap: 24px;
+    margin-bottom: 24px;
     align-items: flex-end;
 `;
 
 const Img = styled.img`
     width: 150px;
     height: 250px;
-    object-fit: contain;
+    object-fit: cover;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 `;
 
 const InfoWrap = styled.div`
-    width: 100%;
-    height: 100%;
-    margin-bottom: 20px;
+    flex: 1;
 `;
+
 const Title = styled.h2`
-    font-weight: bold;
     font-size: 24px;
+    font-weight: 700;
+    margin-bottom: 12px;
+    color: #333;
 `;
 
 const MetaInfo = styled.p`
-    margin-top: 5px;
     font-size: 14px;
-    color: gray;
+    color: #666;
+    margin: 4px 0;
 `;
 
 const Description = styled.p`
-    font-size: 14px;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid #ccc;
+    font-size: 16px;
+    line-height: 1.6;
+    color: #444;
+    margin-bottom: 24px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid #eee;
 `;
 export {
     PopupOverlay,

--- a/fe/src/styles/BookInfoModalStyle.ts
+++ b/fe/src/styles/BookInfoModalStyle.ts
@@ -1,0 +1,84 @@
+import styled, { keyframes } from "styled-components";
+import { CloseOutlined } from "@ant-design/icons";
+
+const modalShow = keyframes`
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+`;
+const PopupOverlay = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(249, 250, 251, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    animation: ${modalShow} 0.2s ease-in-out forwards;
+`;
+
+const PopupCard = styled.div`
+    background-color: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    padding: 16px;
+    max-width: 42rem;
+    min-width: 300px;
+`;
+
+const CloseBtn = styled(CloseOutlined)`
+    display: block;
+    text-align: right;
+`;
+
+const BookInfoWrap = styled.div`
+    width: 100%;
+    display: flex;
+    gap: 1.5rem;
+    align-items: flex-end;
+`;
+
+const Img = styled.img`
+    width: 150px;
+    height: 250px;
+    object-fit: contain;
+`;
+
+const InfoWrap = styled.div`
+    width: 100%;
+    height: 100%;
+    margin-bottom: 20px;
+`;
+const Title = styled.h2`
+    font-weight: bold;
+    font-size: 24px;
+`;
+
+const MetaInfo = styled.p`
+    margin-top: 5px;
+    font-size: 14px;
+    color: gray;
+`;
+
+const Description = styled.p`
+    font-size: 14px;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid #ccc;
+`;
+export {
+    PopupOverlay,
+    PopupCard,
+    CloseBtn,
+    BookInfoWrap,
+    Img,
+    InfoWrap,
+    Title,
+    MetaInfo,
+    Description,
+};

--- a/fe/src/styles/LibrariesPagingStyle.ts
+++ b/fe/src/styles/LibrariesPagingStyle.ts
@@ -3,11 +3,11 @@ import styled from "styled-components";
 const Container = styled.div`
     width: 100%;
     height: 100%;
-    padding: 1rem 0;
+    padding-bottom: 1rem;
 `
 
 const Input = styled.input`
-    width: 50%;
+    width: 60%;
     height: 2rem;
     border: 1px solid var(--border-color);
     border-radius: 8px;
@@ -22,7 +22,7 @@ const LibrariesWrap = styled.div`
 `
 
 const LibraryItem = styled.a`
-    font-size: 12px;
+    font-size: 13px;
     margin: 2px 0;
     color: black;
     text-decoration: none;
@@ -33,4 +33,10 @@ const LibraryItem = styled.a`
     }
 `;
 
-export {Container, Input, LibrariesWrap, LibraryItem}
+const PagingWrap = styled.div`
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+`;
+
+export {Container, Input, LibrariesWrap, LibraryItem, PagingWrap}

--- a/fe/src/styles/LibrariesPagingStyle.ts
+++ b/fe/src/styles/LibrariesPagingStyle.ts
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+const Container = styled.div`
+    width: 100%;
+    height: 100%;
+    padding: 1rem 0;
+`
+
+const Input = styled.input`
+    width: 50%;
+    height: 2rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    margin: 15px auto;
+    padding: 0 0.6rem;
+    outline: none;
+`
+const LibrariesWrap = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+`
+
+const LibraryItem = styled.a`
+    font-size: 12px;
+    margin: 2px 0;
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+    &:hover {
+        text-decoration: underline;
+        color: #1a0dab;
+    }
+`;
+
+export {Container, Input, LibrariesWrap, LibraryItem}

--- a/fe/src/tests/componentsTests/BookDisplay.test.tsx
+++ b/fe/src/tests/componentsTests/BookDisplay.test.tsx
@@ -34,6 +34,7 @@ const mockBooks = {
             image_url: "/images/book2.jpg",
         },
     ],
+    totalPages: 3,
 };
 
 beforeAll(() => {
@@ -106,5 +107,35 @@ describe("BooksDisplay 컴포넌트", () => {
 
         const spinElement = document.querySelector('.ant-spin');
         expect(spinElement).toBeInTheDocument();
+    });
+
+    test("스크롤하여 페이지가 증가하는지 확인", async () => {
+        let currentPage = 1;
+        (useQueryData as jest.Mock).mockReturnValue(() => {
+            return {
+                data: {
+                    ...mockBooks,
+                    content: mockBooks.content.slice(0, currentPage),
+                },
+                isLoading: false,
+                isFetching: false,
+            };
+        });
+
+        const { container } = render(<BooksDisplay />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Book One")).toBeInTheDocument();
+        });
+
+        const observerDiv = container.querySelector('div[style="height: 10px;"]');
+        expect(observerDiv).toBeInTheDocument();
+
+        currentPage = 2;
+        observerDiv && (new IntersectionObserver(() => {}).observe(observerDiv));
+
+        await waitFor(() => {
+            expect(screen.getByText("Book Two")).toBeInTheDocument();
+        });
     });
 });

--- a/fe/src/tests/componentsTests/BookInfoModal.test.tsx
+++ b/fe/src/tests/componentsTests/BookInfoModal.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import BookInfoModal from "@/components/BookInfoModal/BookInfoModal";
+import { vi } from "vitest";
+import { BookContent } from "@/types/Books";
+
+vi.mock("@/styles/BookInfoModalStyle", () => ({
+    PopupOverlay: "div",
+    PopupCard: "div",
+    CloseBtn: "button",
+    BookInfoWrap: "div",
+    Img: "img",
+    InfoWrap: "div",
+    Title: "h2",
+    MetaInfo: "p",
+    Description: "p",
+}));
+
+const mockBookData: BookContent = {
+    id: "1",
+    title: "Test Book",
+    author: "Test Author",
+    provider: "Test Provider",
+    publisher: "Test Publisher",
+    imageUrl: "test-image-url.jpg",
+    libraryResponses: [],
+};
+
+describe("BookInfoModal 컴포넌트 테스트", () => {
+    const handleModalClose = vi.fn();
+
+    beforeAll(() => {
+        Object.defineProperty(window, "matchMedia", {
+            writable: true,
+            value: vi.fn().mockImplementation(query => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            })),
+        });
+    });
+
+    test("책 정보가 올바르게 표시되는지 확인", () => {
+        render(<BookInfoModal bookData={mockBookData} handleModalClose={handleModalClose} />);
+
+        expect(screen.getByText("Test Book")).toBeInTheDocument();
+        expect(screen.getByText("저자: Test Author")).toBeInTheDocument();
+        expect(screen.getByText("제공: Test Provider")).toBeInTheDocument();
+        expect(screen.getByText("출판사: Test Publisher")).toBeInTheDocument();
+
+        const bookImage = screen.getByAltText("Test Book");
+        expect(bookImage).toBeInTheDocument();
+        expect(bookImage).toHaveAttribute("src", "http://test-image-url.jpg");
+    });
+
+    test("모달 외부를 클릭하면 모달이 닫히는지 확인", () => {
+        render(<BookInfoModal bookData={mockBookData} handleModalClose={handleModalClose} />);
+
+        fireEvent.mouseDown(document.body);
+
+        expect(handleModalClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/fe/src/tests/componentsTests/LibrariesPaging.test.tsx
+++ b/fe/src/tests/componentsTests/LibrariesPaging.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import LibrariesPaging from "@/components/BookInfoModal/LibrariesPaging";
+import { LibrariesResponseType } from "@/types/LibrariesResponse";
+import { vi } from "vitest";
+
+vi.mock("@/styles/LibrariesPagingStyle", () => ({
+    Container: "div",
+    Input: "input",
+    LibrariesWrap: "div",
+    LibraryItem: "a",
+    PagingWrap: "div",
+}));
+
+const mockLibraries: LibrariesResponseType[] = [
+    {id: "Id A", LibraryName: "Library A", BookLibraryUrl: "http://library-a.com" },
+    {id: "Id B", LibraryName: "Library B", BookLibraryUrl: "http://library-b.com" },
+    {id: "Id C", LibraryName: "Library C", BookLibraryUrl: "http://library-c.com" },
+    {id: "Id D", LibraryName: "Library D", BookLibraryUrl: "http://library-d.com" },
+];
+
+describe("LibrariesPaging 컴포넌트 테스트", () => {
+    beforeAll(() => {
+        Object.defineProperty(window, "matchMedia", {
+            writable: true,
+            value: vi.fn().mockImplementation(query => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addListener: vi.fn(),
+                removeListener: vi.fn(),
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+                dispatchEvent: vi.fn(),
+            })),
+        });
+    });
+
+    test("초기 렌더링 시 도서관 목록이 올바르게 표시되는지 확인", () => {
+        render(<LibrariesPaging libraryResponses={mockLibraries} />);
+
+        expect(screen.getByText("Library A")).toBeInTheDocument();
+        expect(screen.getByText("Library B")).toBeInTheDocument();
+        expect(screen.getByText("Library C")).toBeInTheDocument();
+        expect(screen.getByText("Library D")).toBeInTheDocument();
+    });
+
+    test("검색 필터링이 올바르게 동작하는지 확인", async() => {
+        render(<LibrariesPaging libraryResponses={mockLibraries} />);
+
+        const searchInput = screen.getByPlaceholderText("도서관 검색...");
+        fireEvent.change(searchInput, { target: { value: "Library A" } });
+
+        await waitFor(() => {
+            expect(screen.getByText("Library A")).toBeInTheDocument();
+            expect(screen.queryByText("Library B")).not.toBeInTheDocument();
+            expect(screen.queryByText("Library C")).not.toBeInTheDocument();
+            expect(screen.queryByText("Library D")).not.toBeInTheDocument();
+        })
+    });
+});

--- a/fe/src/tests/hooksTests/useOnClickOutside.test.tsx
+++ b/fe/src/tests/hooksTests/useOnClickOutside.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import useOnClickOutside from "@/hooks/useOnClickOutside";
+import { useRef, useState } from "react";
+
+const TestComponent = () => {
+    const testRef = useRef(null)
+    const [isOpen, setIsOpen] = useState(true)
+
+    const closeModal = () => setIsOpen(false)
+
+    useOnClickOutside(testRef, closeModal)
+    return (
+        <div>
+            <div>modal</div>
+            {isOpen && <div ref={testRef}>modal open</div>}
+        </div>
+    )
+}
+
+describe("useOnClickOutside Hook 테스트.", () => {
+    test("innerRef의 외부를 클릭했을때 모달이 닫히는지 확인.", () => {
+        render(<TestComponent/>)
+
+        expect(screen.getByText("modal open")).toBeInTheDocument()
+
+        fireEvent.mouseDown(screen.getByText("modal"));
+
+        expect(screen.queryByTestId("modal")).not.toBeInTheDocument();
+    })
+
+    test("innerRef를 클릭했을때 모달이 닫히지 않는지 확인.", () => {
+        render(<TestComponent/>)
+
+        expect(screen.getByText("modal open")).toBeInTheDocument();
+
+        fireEvent.mouseDown(screen.getByText("modal open"))
+
+        expect(screen.getByText("modal open")).toBeInTheDocument();
+    })
+})

--- a/fe/src/types/Libraries.ts
+++ b/fe/src/types/Libraries.ts
@@ -1,5 +1,4 @@
 export interface LibrariesType {
     id: string;
-    LibraryName: string;
-    BookLibraryUrl: string;
+    name: string;
 }

--- a/fe/src/types/Libraries.ts
+++ b/fe/src/types/Libraries.ts
@@ -1,4 +1,5 @@
 export interface LibrariesType {
     id: string;
-    name: string;
+    LibraryName: string;
+    BookLibraryUrl: string;
 }

--- a/fe/src/types/LibrariesResponse.ts
+++ b/fe/src/types/LibrariesResponse.ts
@@ -1,0 +1,5 @@
+export interface LibrariesResponseType {
+    id: string;
+    LibraryName: string;
+    BookLibraryUrl: string;
+}

--- a/fe/src/types/PageNation.ts
+++ b/fe/src/types/PageNation.ts
@@ -1,0 +1,1 @@
+export const LIBRARIES_PER_PAGE = 5;


### PR DESCRIPTION
## 변경 사항
- 책 클릭 시 도서 정보를 보여주는 팝업 기능 추가
- useOnClickOutside hook 구현
- 팝업 카드가 아닌 외부 클릭시 팝업이 닫히는 기능 구현
- useDebounce를 재활용해 검색한 뒤 0.3초 뒤 검색 결과가 나오도록 구현
- 페이지네이션으로 도서관을 페이징할 수 있는 기능 구현

## 관련 이슈
#65

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [ ] 버그 수정
- [X] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)
![팝업기능구현GIF](https://github.com/user-attachments/assets/22a560e6-f1cf-4bf7-b16e-811d88981231)
