### PR TITLE
[BE] 기존에 web-api를 어드민 및 유저 api로 분리했습니다.

### DIFF
--- a/be/ebook-search/ebook-web/src/docs/asciidoc/admin-book.adoc
+++ b/be/ebook-search/ebook-web/src/docs/asciidoc/admin-book.adoc
@@ -1,0 +1,13 @@
+= 관리자 도서 API
+
+== 책 저장 API
+
+operation::create-book[snippets='http-request,request-body,http-response,response-headers']
+
+== 책 업데이트 API
+
+operation::update-book[snippets='http-request,path-parameters,request-body,http-response,response-headers']
+
+== 책 삭제 API
+
+operation::delete-book[snippets='http-request,path-parameters,http-response']

--- a/be/ebook-search/ebook-web/src/docs/asciidoc/admin-library.adoc
+++ b/be/ebook-search/ebook-web/src/docs/asciidoc/admin-library.adoc
@@ -1,0 +1,13 @@
+= 관리자 도서관 API
+
+== 도서관 저장 API
+
+operation::create-library[snippets='http-request,request-body,http-response,response-headers']
+
+== 도서관 업데이트 API
+
+operation::update-library[snippets='http-request,path-parameters,request-body,http-response,response-headers']
+
+== 도서관 삭제 API
+
+operation::delete-library[snippets='http-request,path-parameters,http-response']

--- a/be/ebook-search/ebook-web/src/docs/asciidoc/admin-verification.adoc
+++ b/be/ebook-search/ebook-web/src/docs/asciidoc/admin-verification.adoc
@@ -1,0 +1,5 @@
+= 관리자 검증 API
+
+== 도서관별 책 권수 검증 API
+
+operation::verify-book-count[snippets='http-request,http-response,response-fields,response-body']

--- a/be/ebook-search/ebook-web/src/docs/asciidoc/book.adoc
+++ b/be/ebook-search/ebook-web/src/docs/asciidoc/book.adoc
@@ -1,20 +1,4 @@
-== 책 검색 API
+= 사용자 도서 API
 
 operation::search-books[snippets='http-request,query-parameters,http-response,response-fields,response-body']
 
-== 책 저장 API
-
-operation::create-book[snippets='http-request,request-body,http-response,response-headers']
-
-
-== 책 업데이트 API
-
-operation::update-book[snippets='http-request,path-parameters,request-body,http-response,response-headers']
-
-== 책 삭제 API
-
-operation::delete-book[snippets='http-request,path-parameters,http-response']
-
-== 도서관별 책 권수 검증 API
-
-operation::verify-book-count[snippets='http-request,http-response,response-fields,response-body']

--- a/be/ebook-search/ebook-web/src/docs/asciidoc/index.adoc
+++ b/be/ebook-search/ebook-web/src/docs/asciidoc/index.adoc
@@ -2,8 +2,14 @@
 
 == 목차
 
+=== User API
 * link:book.html[도서 API]
 * link:library.html[도서관 API]
+
+=== Admin API
+* link:admin-book.adoc[관리자 도서 API]
+* link:admin-library.adoc[관리자 도서관 API]
+* link:admin-verification.adoc[검증 API]
 
 == 개요
 

--- a/be/ebook-search/ebook-web/src/docs/asciidoc/library.adoc
+++ b/be/ebook-search/ebook-web/src/docs/asciidoc/library.adoc
@@ -1,3 +1,5 @@
+= 사용자 도서관 API
+
 == 전체 도서관 목록 조회 API
 
 operation::libraries[snippets='http-request,http-response,response-fields,response-body']
@@ -5,15 +7,3 @@ operation::libraries[snippets='http-request,http-response,response-fields,respon
 == 단일 도서관 조회
 
 operation::library[snippets='http-request,path-parameters,http-response,response-fields,response-body']
-
-== 도서관 저장 API
-
-operation::create-library[snippets='http-request,request-body,http-response,response-headers']
-
-== 도서관 업데이트 API
-
-operation::update-library[snippets='http-request,path-parameters,request-body,http-response,response-headers']
-
-== 도서관 삭제 API
-
-operation::delete-library[snippets='http-request,path-parameters,http-response']

--- a/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/BookController.java
+++ b/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/BookController.java
@@ -1,26 +1,15 @@
 package com.meetyourbook.controller;
 
-import com.meetyourbook.dto.BookCreateRequest;
 import com.meetyourbook.dto.BookPageResponse;
 import com.meetyourbook.dto.BookSearchRequest;
-import com.meetyourbook.dto.BookUpdateRequest;
 import com.meetyourbook.service.BookService;
-import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/books")
+@RequestMapping("/books")
 @RequiredArgsConstructor
 public class BookController {
 
@@ -31,23 +20,4 @@ public class BookController {
         return bookService.searchBooks(request);
     }
 
-    @PostMapping
-    public ResponseEntity<Void> createBook(@RequestBody @Valid BookCreateRequest request) {
-        UUID id = bookService.createBook(request);
-        URI location = URI.create("/api/books/" + id);
-        return ResponseEntity.created(location).build();
-    }
-
-    @DeleteMapping("/{bookId}")
-    public ResponseEntity<Void> deleteBook(@PathVariable UUID bookId) {
-        bookService.deleteBook(bookId);
-        return ResponseEntity.noContent().build();
-    }
-
-    @PatchMapping("/{bookId}")
-    public ResponseEntity<?> updateBook(@PathVariable UUID bookId,
-        @RequestBody @Valid BookUpdateRequest request) {
-        bookService.updateBook(bookId, request);
-        return ResponseEntity.noContent().location(URI.create("/api/books/" + bookId)).build();
-    }
 }

--- a/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/LibraryController.java
+++ b/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/LibraryController.java
@@ -1,24 +1,17 @@
 package com.meetyourbook.controller;
 
-import com.meetyourbook.dto.LibraryCreateRequest;
 import com.meetyourbook.dto.LibraryResponse;
-import com.meetyourbook.dto.LibraryUpdateRequest;
 import com.meetyourbook.service.LibraryWebService;
-import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/libraries")
+@RequestMapping("/libraries")
 @RequiredArgsConstructor
 public class LibraryController {
 
@@ -33,27 +26,6 @@ public class LibraryController {
     public ResponseEntity<LibraryResponse> getLibrary(@PathVariable Long libraryId) {
         LibraryResponse response = libraryWebService.findById(libraryId);
         return ResponseEntity.ok(response);
-    }
-
-    @PostMapping
-    public ResponseEntity<Void> createLibrary(@RequestBody LibraryCreateRequest request) {
-        Long libraryId = libraryWebService.createLibrary(request);
-        URI location = URI.create("/api/libraries/" + libraryId);
-        return ResponseEntity.created(location).build();
-    }
-
-    @PatchMapping("/{libraryId}")
-    public ResponseEntity<LibraryResponse> updateLibrary(@PathVariable Long libraryId,
-        @RequestBody LibraryUpdateRequest request) {
-        libraryWebService.updateLibrary(libraryId, request);
-        return ResponseEntity.noContent().location(URI.create("api/libraries/" + libraryId))
-            .build();
-    }
-
-    @DeleteMapping("/{libraryId}")
-    public ResponseEntity<Void> deleteLibrary(@PathVariable Long libraryId) {
-        libraryWebService.delete(libraryId);
-        return ResponseEntity.noContent().build();
     }
 
 }

--- a/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/admin/AdminBookController.java
+++ b/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/admin/AdminBookController.java
@@ -1,0 +1,56 @@
+package com.meetyourbook.controller.admin;
+
+import com.meetyourbook.dto.BookCreateRequest;
+import com.meetyourbook.dto.BookUpdateRequest;
+import com.meetyourbook.service.BookService;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("/admin/books")
+@RequiredArgsConstructor
+public class AdminBookController {
+
+    private final BookService bookService;
+
+    @PostMapping
+    public ResponseEntity<Void> createBook(@RequestBody @Valid BookCreateRequest request) {
+        UUID id = bookService.createBook(request);
+        URI location = ServletUriComponentsBuilder
+            .fromCurrentRequest()
+            .path("/{id}")
+            .buildAndExpand(id)
+            .toUri();
+        return ResponseEntity.created(location).build();
+    }
+
+    @DeleteMapping("/{bookId}")
+    public ResponseEntity<Void> deleteBook(@PathVariable UUID bookId) {
+        bookService.deleteBook(bookId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{bookId}")
+    public ResponseEntity<?> updateBook(@PathVariable UUID bookId,
+        @RequestBody @Valid BookUpdateRequest request) {
+        bookService.updateBook(bookId, request);
+        URI location = ServletUriComponentsBuilder
+            .fromCurrentRequest()
+            .path("/{id}")
+            .buildAndExpand(bookId)
+            .toUri();
+        return ResponseEntity.noContent().location(location).build();
+    }
+
+}

--- a/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/admin/AdminLibraryController.java
+++ b/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/admin/AdminLibraryController.java
@@ -1,0 +1,55 @@
+package com.meetyourbook.controller.admin;
+
+import com.meetyourbook.dto.LibraryCreateRequest;
+import com.meetyourbook.dto.LibraryResponse;
+import com.meetyourbook.dto.LibraryUpdateRequest;
+import com.meetyourbook.service.LibraryWebService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("/admin/libraries")
+@RequiredArgsConstructor
+public class AdminLibraryController {
+
+    private final LibraryWebService libraryWebService;
+
+    @PostMapping
+    public ResponseEntity<Void> createLibrary(@RequestBody LibraryCreateRequest request) {
+        Long libraryId = libraryWebService.createLibrary(request);
+        URI location = ServletUriComponentsBuilder
+            .fromCurrentRequest()
+            .path("/{id}")
+            .buildAndExpand(libraryId)
+            .toUri();
+        return ResponseEntity.created(location).build();
+    }
+
+    @PatchMapping("/{libraryId}")
+    public ResponseEntity<LibraryResponse> updateLibrary(@PathVariable Long libraryId,
+        @RequestBody LibraryUpdateRequest request) {
+        libraryWebService.updateLibrary(libraryId, request);
+        URI location = ServletUriComponentsBuilder
+            .fromCurrentRequest()
+            .path("/{id}")
+            .buildAndExpand(libraryId)
+            .toUri();
+        return ResponseEntity.noContent().location(location).build();
+    }
+
+    @DeleteMapping("/{libraryId}")
+    public ResponseEntity<Void> deleteLibrary(@PathVariable Long libraryId) {
+        libraryWebService.delete(libraryId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/admin/BookVerificationController.java
+++ b/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/controller/admin/BookVerificationController.java
@@ -1,4 +1,4 @@
-package com.meetyourbook.controller;
+package com.meetyourbook.controller.admin;
 
 import com.meetyourbook.dto.BookCountVerificationResult;
 import com.meetyourbook.service.BookCountVerificationService;
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/admin")
+@RequestMapping("/admin")
 @RequiredArgsConstructor
 public class BookVerificationController {
 

--- a/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/BookControllerTest.java
+++ b/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/BookControllerTest.java
@@ -2,32 +2,22 @@ package com.meetyourbook.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.meetyourbook.dto.BookCreateRequest;
 import com.meetyourbook.dto.BookLibraryResponse;
 import com.meetyourbook.dto.BookPageResponse;
 import com.meetyourbook.dto.BookSearchRequest;
-import com.meetyourbook.dto.BookUpdateRequest;
 import com.meetyourbook.dto.SimpleBookResponse;
 import com.meetyourbook.service.BookService;
-import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
@@ -45,16 +35,13 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(BookController.class)
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-public class BookControllerTest {
+class BookControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private BookService bookService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("책 검색 요청 성공")
@@ -118,7 +105,7 @@ public class BookControllerTest {
 
         // When, Then
         mockMvc.perform(
-                get("/api/books")
+                get("/books")
                     .param("title", bookSearchRequest.title())
                     .param("author", bookSearchRequest.author())
                     .param("publisher", bookSearchRequest.publisher())
@@ -153,63 +140,5 @@ public class BookControllerTest {
                         "책 상세 페이지 주소"))));
 
     }
-
-    @Test
-    @DisplayName("책 저장 요청 성공")
-    void createBook_success() throws Exception {
-        // Given
-        BookCreateRequest bookCreateRequest = new BookCreateRequest("사피엔스", "유발 하라리", "김영사", "교보문고",
-            LocalDate.of(2024, 1, 1), "https://test.com/image");
-        String requestBody = objectMapper.writeValueAsString(bookCreateRequest);
-
-        // When, Then
-        mockMvc.perform(
-                post("/api/books")
-                    .contentType("application/json")
-                    .content(requestBody))
-            .andExpect(status().isCreated())
-            .andDo(document("create-book",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                responseHeaders(headerWithName("Location").description("생성된 책의 URL"))));
-    }
-
-    @Test
-    @DisplayName("책 삭제 요청 성공")
-    void deleteBook_success() throws Exception {
-        // Given
-        UUID bookId = UUID.randomUUID();
-
-        // When, Then
-        mockMvc.perform(delete("/api/books/{bookId}", bookId))
-            .andExpect(status().isNoContent())
-            .andDo(document("delete-book",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(parameterWithName("bookId").description("책 ID"))));
-    }
-
-    @Test
-    @DisplayName("책 수정 요청 성공")
-    void updateBook_success() throws Exception {
-        // Given
-        UUID bookId = UUID.randomUUID();
-        BookUpdateRequest bookUpdateRequest = new BookUpdateRequest("사피엔스", "유발 하라리", "김영사", "교보문고",
-            LocalDate.of(2024, 1, 1), "https://test.com/image_sapiens");
-        String requestBody = objectMapper.writeValueAsString(bookUpdateRequest);
-
-        // When, Then
-        mockMvc.perform(
-                patch("/api/books/{bookId}", bookId)
-                    .contentType("application/json")
-                    .content(requestBody))
-            .andExpect(status().isNoContent())
-            .andDo(document("update-book",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(parameterWithName("bookId").description("책 ID")),
-                responseHeaders(headerWithName("Location").description("수정된 책의 URL"))));
-    }
-
 
 }

--- a/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/LibraryControllerTest.java
+++ b/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/LibraryControllerTest.java
@@ -2,13 +2,8 @@ package com.meetyourbook.controller;
 
 
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -18,10 +13,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.meetyourbook.dto.LibraryCreateRequest;
 import com.meetyourbook.dto.LibraryResponse;
-import com.meetyourbook.dto.LibraryUpdateRequest;
 import com.meetyourbook.service.LibraryWebService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -46,9 +38,6 @@ class LibraryControllerTest {
     @MockBean
     private LibraryWebService libraryWebService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
 
     @Test
     @DisplayName("도서관 목록 조회 요청 성공")
@@ -65,7 +54,7 @@ class LibraryControllerTest {
         );
 
         // When, Then
-        mockMvc.perform(get("/api/libraries"))
+        mockMvc.perform(get("/libraries"))
             .andExpect(status().isOk())
             .andDo(document("libraries",
                 preprocessRequest(prettyPrint()),
@@ -86,7 +75,7 @@ class LibraryControllerTest {
         when(libraryWebService.findById(libraryId1)).thenReturn(libraryResponse);
 
         // When, Then
-        mockMvc.perform(get("/api/libraries/{id}", libraryId1))
+        mockMvc.perform(get("/libraries/{id}", libraryId1))
             .andExpect(status().isOk())
             .andDo(document("library",
                 preprocessRequest(prettyPrint()),
@@ -100,63 +89,5 @@ class LibraryControllerTest {
                 )
             ));
 
-    }
-
-    @Test
-    @DisplayName("도서관 생성 요청 성공")
-    void createLibrary() throws Exception {
-        // Given
-        LibraryCreateRequest libraryCreateRequest = new LibraryCreateRequest("대학교", "서울대학교",
-            "https://test.com");
-        String createRequest = objectMapper.writeValueAsString(libraryCreateRequest);
-
-        // When, Then
-        mockMvc.perform(post("/api/libraries")
-                .contentType("application/json")
-                .content(createRequest))
-            .andExpect(status().isCreated())
-            .andDo(document("create-library",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                responseHeaders(headerWithName("Location").description("생성된 도서관의 URL"))
-            ));
-    }
-
-    @Test
-    @DisplayName("도서관 수정 요청 성공")
-    void updateLibrary_success() throws Exception {
-        // Given
-        LibraryUpdateRequest libraryUpdateRequest = new LibraryUpdateRequest("대학교", "서울대학교",
-            "https://test.com");
-        String updateRequest = objectMapper.writeValueAsString(libraryUpdateRequest);
-
-        // When
-        mockMvc.perform(patch("/api/libraries/{id}", 1L)
-                .contentType("application/json")
-                .content(updateRequest))
-            .andExpect(status().isNoContent())
-            .andDo(document("update-library",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(parameterWithName("id").description("도서관 ID")),
-                responseHeaders(headerWithName("Location").description("수정된 도서관의 URL"))
-            ));
-
-    }
-
-    @Test
-    @DisplayName("도서관 삭제 요청 성공")
-    void deleteLibrary() throws Exception {
-        // Given
-        Long libraryId = 1L;
-
-        // When, Then
-        mockMvc.perform(delete("/api/libraries/{id}", libraryId))
-            .andExpect(status().isNoContent())
-            .andDo(document("delete-library",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(parameterWithName("id").description("도서관 ID"))
-            ));
     }
 }

--- a/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/AdminBookControllerTest.java
+++ b/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/AdminBookControllerTest.java
@@ -1,0 +1,104 @@
+package com.meetyourbook.controller.admin;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetyourbook.dto.BookCreateRequest;
+import com.meetyourbook.dto.BookUpdateRequest;
+import com.meetyourbook.service.BookService;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminBookController.class)
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+public class AdminBookControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private BookService bookService;
+
+
+    @Test
+    @DisplayName("책 저장 요청 성공")
+    void createBook_success() throws Exception {
+        // Given
+        BookCreateRequest bookCreateRequest = new BookCreateRequest("사피엔스", "유발 하라리", "김영사", "교보문고",
+            LocalDate.of(2024, 1, 1), "https://test.com/image");
+        String requestBody = objectMapper.writeValueAsString(bookCreateRequest);
+
+        // When, Then
+        mockMvc.perform(
+                post("/admin/books")
+                    .contentType("application/json")
+                    .content(requestBody))
+            .andExpect(status().isCreated())
+            .andDo(document("create-book",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseHeaders(headerWithName("Location").description("생성된 책의 URL"))));
+    }
+
+    @Test
+    @DisplayName("책 삭제 요청 성공")
+    void deleteBook_success() throws Exception {
+        // Given
+        UUID bookId = UUID.randomUUID();
+
+        // When, Then
+        mockMvc.perform(delete("/admin/books/{bookId}", bookId))
+            .andExpect(status().isNoContent())
+            .andDo(document("delete-book",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("bookId").description("책 ID"))));
+    }
+
+    @Test
+    @DisplayName("책 수정 요청 성공")
+    void updateBook_success() throws Exception {
+        // Given
+        UUID bookId = UUID.randomUUID();
+        BookUpdateRequest bookUpdateRequest = new BookUpdateRequest("사피엔스", "유발 하라리", "김영사", "교보문고",
+            LocalDate.of(2024, 1, 1), "https://test.com/image_sapiens");
+        String requestBody = objectMapper.writeValueAsString(bookUpdateRequest);
+
+        // When, Then
+        mockMvc.perform(
+                patch("/admin/books/{bookId}", bookId)
+                    .contentType("application/json")
+                    .content(requestBody))
+            .andExpect(status().isNoContent())
+            .andDo(document("update-book",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("bookId").description("책 ID")),
+                responseHeaders(headerWithName("Location").description("수정된 책의 URL"))));
+    }
+
+}

--- a/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/AdminBookControllerTest.java
+++ b/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/AdminBookControllerTest.java
@@ -32,7 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(AdminBookController.class)
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-public class AdminBookControllerTest {
+class AdminBookControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/AdminLibraryControllerTest.java
+++ b/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/AdminLibraryControllerTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(AdminLibraryController.class)
 @AutoConfigureRestDocs
 @ExtendWith(RestDocumentationExtension.class)
-public class AdminLibraryControllerTest {
+class AdminLibraryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/AdminLibraryControllerTest.java
+++ b/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/AdminLibraryControllerTest.java
@@ -1,0 +1,103 @@
+package com.meetyourbook.controller.admin;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meetyourbook.dto.LibraryCreateRequest;
+import com.meetyourbook.dto.LibraryUpdateRequest;
+import com.meetyourbook.service.LibraryWebService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminLibraryController.class)
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+public class AdminLibraryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LibraryWebService libraryWebService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    @Test
+    @DisplayName("도서관 생성 요청 성공")
+    void createLibrary() throws Exception {
+        // Given
+        LibraryCreateRequest libraryCreateRequest = new LibraryCreateRequest("대학교", "서울대학교",
+            "https://test.com");
+        String createRequest = objectMapper.writeValueAsString(libraryCreateRequest);
+
+        // When, Then
+        mockMvc.perform(post("/admin/libraries")
+                .contentType("application/json")
+                .content(createRequest))
+            .andExpect(status().isCreated())
+            .andDo(document("create-library",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                responseHeaders(headerWithName("Location").description("생성된 도서관의 URL"))
+            ));
+    }
+
+    @Test
+    @DisplayName("도서관 수정 요청 성공")
+    void updateLibrary_success() throws Exception {
+        // Given
+        LibraryUpdateRequest libraryUpdateRequest = new LibraryUpdateRequest("대학교", "서울대학교",
+            "https://test.com");
+        String updateRequest = objectMapper.writeValueAsString(libraryUpdateRequest);
+
+        // When
+        mockMvc.perform(patch("/admin/libraries/{id}", 1L)
+                .contentType("application/json")
+                .content(updateRequest))
+            .andExpect(status().isNoContent())
+            .andDo(document("update-library",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("id").description("도서관 ID")),
+                responseHeaders(headerWithName("Location").description("수정된 도서관의 URL"))
+            ));
+
+    }
+
+    @Test
+    @DisplayName("도서관 삭제 요청 성공")
+    void deleteLibrary() throws Exception {
+        // Given
+        Long libraryId = 1L;
+
+        // When, Then
+        mockMvc.perform(delete("/admin/libraries/{id}", libraryId))
+            .andExpect(status().isNoContent())
+            .andDo(document("delete-library",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("id").description("도서관 ID"))
+            ));
+    }
+
+}

--- a/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/BookVerificationControllerTest.java
+++ b/be/ebook-search/ebook-web/src/test/java/com/meetyourbook/controller/admin/BookVerificationControllerTest.java
@@ -1,4 +1,4 @@
-package com.meetyourbook.controller;
+package com.meetyourbook.controller.admin;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -45,7 +45,7 @@ class BookVerificationControllerTest {
             List.of(bookCountVerificationResult));
 
         // When, Then
-        mockMvc.perform(get("/api/admin/verify-book-count"))
+        mockMvc.perform(get("/admin/verify-book-count"))
             .andExpect(status().isOk())
             .andDo(document("verify-book-count",
                 preprocessRequest(prettyPrint()),


### PR DESCRIPTION
## 변경 사항
- 기존에 request mapping으로 지정해준 api를 삭제 -> 서브도메인으로 대체합니다.
- 생성, 삭제, 업데이트, 검증 api를 어드민 권한으로 변경했습니다.
- api 문서는 /docs/index.html에서 확인할 수 있습니다.

## 관련 이슈
#74 

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [x] 리팩토링
- [x] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)
x

## 추가 설명
x