### PR TITLE
[BE] 도서관 검색 api로부터 도서관 정보를 db에 저장

### DIFF
--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/LibraryCrawlerController.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/controller/LibraryCrawlerController.java
@@ -1,9 +1,11 @@
 package com.meetyourbook.controller;
 
 import com.meetyourbook.dto.ImportResult;
+import com.meetyourbook.dto.KyoboLibraryApiRequest;
 import com.meetyourbook.dto.LibraryCrawlerRequest;
 import com.meetyourbook.service.LibraryCrawlerService;
 import com.meetyourbook.service.LibraryImportService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +32,13 @@ public class LibraryCrawlerController {
     @PostMapping("/crawl")
     public ResponseEntity<?> startCrawling(@RequestBody LibraryCrawlerRequest request) {
         libraryCrawlerService.crawl(request);
+        return ResponseEntity.ok("크롤링을 시작했습니다.");
+    }
+
+    @PostMapping("/crawl-kyobo-api")
+    public ResponseEntity<?> startCrawlingKyoboApi(
+        @Valid @RequestBody KyoboLibraryApiRequest request) {
+        libraryCrawlerService.crawlLibraryApi(request);
         return ResponseEntity.ok("크롤링을 시작했습니다.");
     }
 }

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/dto/KyoboLibraryApiRequest.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/dto/KyoboLibraryApiRequest.java
@@ -1,0 +1,12 @@
+package com.meetyourbook.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record KyoboLibraryApiRequest(
+
+    @NotNull
+    String url
+
+) {
+
+}

--- a/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/dto/LibraryCrawlResult.java
+++ b/be/ebook-search/ebook-crawler/src/main/java/com/meetyourbook/dto/LibraryCrawlResult.java
@@ -12,4 +12,8 @@ public record LibraryCrawlResult(
 
 ) {
 
+    public LibraryCreationInfo toLibraryCreationInfo() {
+        return new LibraryCreationInfo(libraryName, libraryHost);
+    }
+
 }

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/dto/LibraryCreationInfo.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/dto/LibraryCreationInfo.java
@@ -1,12 +1,10 @@
 package com.meetyourbook.dto;
 
 import com.meetyourbook.entity.Library;
-import com.meetyourbook.entity.Library.LibraryType;
 import lombok.Builder;
 
 @Builder
 public record LibraryCreationInfo(
-    String category,
     String press,
     String url
 ) {
@@ -14,7 +12,6 @@ public record LibraryCreationInfo(
     public Library toEntity() {
         return Library.builder()
             .name(press)
-            .type(LibraryType.findByDescription(category))
             .libraryUrl(url)
             .build();
     }

--- a/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/service/LibraryDomainService.java
+++ b/be/ebook-search/ebook-domain/src/main/java/com/meetyourbook/service/LibraryDomainService.java
@@ -38,6 +38,7 @@ public class LibraryDomainService {
             .toList();
 
         List<Library> savedLibraries = libraryRepository.saveAll(libraries);
+        log.info("총 {}개의 도서관을 저장했습니다.", savedLibraries.size());
         return savedLibraries.size();
     }
 
@@ -50,7 +51,7 @@ public class LibraryDomainService {
     @Transactional(readOnly = true)
     public List<Library> findLibrariesByIdRange(Long startId, Long endId) {
         return libraryRepository.findByIdBetween(startId, endId);
-        
+
     }
 
     @Transactional

--- a/be/ebook-search/ebook-domain/src/test/java/com/meetyourbook/service/LibraryDomainServiceTest.java
+++ b/be/ebook-search/ebook-domain/src/test/java/com/meetyourbook/service/LibraryDomainServiceTest.java
@@ -39,7 +39,7 @@ class LibraryDomainServiceTest {
     @DisplayName("도서관을 추가할 수 있다.")
     void createLibrary() {
         //given
-        LibraryCreationInfo request = new LibraryCreationInfo("대학", "서울대학교",
+        LibraryCreationInfo request = new LibraryCreationInfo("서울대학교",
             "www.snu.elibrary.com");
 
         //when
@@ -57,7 +57,7 @@ class LibraryDomainServiceTest {
             )
             .containsExactly(
                 "서울대학교",
-                UNIVERSITY_LIBRARY,
+                null,
                 "www.snu.elibrary.com"
             );
     }

--- a/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/dto/LibraryCreateRequest.java
+++ b/be/ebook-search/ebook-web/src/main/java/com/meetyourbook/dto/LibraryCreateRequest.java
@@ -10,7 +10,6 @@ public record LibraryCreateRequest(
 
     public LibraryCreationInfo toLibraryCreationInfo() {
         return LibraryCreationInfo.builder()
-            .category(category)
             .press(press)
             .url(url)
             .build();


### PR DESCRIPTION
## 변경 사항
- 도서관 api를 이용해서 도서관 데이터를 저장합니다.
- request body에 url을 입력하면 됩니다.

## 관련 이슈
#24 

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [ ] 리팩토링
- [ ] 문서 내용 변경
- [ ] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)

## 스크린샷 (선택사항)
x

## 추가 설명
x