### PR TITLE
[FE] api 연결 및 mock 데이터와 타입이 다른 에러 수정

### DIFF
--- a/fe/src/components/BooksDisplay/BookCard/BookCard.tsx
+++ b/fe/src/components/BooksDisplay/BookCard/BookCard.tsx
@@ -29,7 +29,7 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
             {viewMode === "grid" ? (
                 <S.GridCard $isVisible={isVisible} onClick={handleModalOpen}>
                     <S.Image
-                        src={`http://${imageUrl}`}
+                        src={`//${imageUrl}`}
                         alt={title}
                         onError={handleImageError}
                         loading="lazy"
@@ -42,7 +42,7 @@ const BookCard = ({ bookData, viewMode }: BookItemProps) => {
             ) : (
                 <S.ListCard $isVisible={isVisible} onClick={handleModalOpen}>
                     <S.Image
-                        src={`http://${imageUrl}`}
+                        src={`//${imageUrl}`}
                         alt={title}
                         onError={handleImageError}
                     />

--- a/fe/src/components/FilterDisplay/LibraryFilter/LibraryFilter.tsx
+++ b/fe/src/components/FilterDisplay/LibraryFilter/LibraryFilter.tsx
@@ -14,7 +14,8 @@ const LibraryFilter = () => {
         toggleFilter,
         handleSearch,
         isLoading,
-        filteredLibraries
+        getDisplayLibraries,
+        observerRef
     } = useLibraryFilter();
 
     return (
@@ -31,10 +32,11 @@ const LibraryFilter = () => {
                 />
                 {isLoading && <LoadingFallBack/>}
                 <LibraryList
-                    libraries={filteredLibraries as LibrariesType[]}
+                    libraries={getDisplayLibraries as LibrariesType[]}
                     librariesFilter={librariesFilter}
                     handleSelectLibrary={handleSelectLibrary}
-                />
+                    />
+                <div ref={observerRef} style={{ height: "10px" }} />
             </S.ListWrap>
         </S.Container>
     );

--- a/fe/src/components/FilterDisplay/LibraryList/LibraryList.tsx
+++ b/fe/src/components/FilterDisplay/LibraryList/LibraryList.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import * as S from "@/styles/LibraryListStyle"
 import { LibrariesType } from "@/types/Libraries";
 
@@ -8,25 +7,24 @@ interface LibraryListProps {
     handleSelectLibrary: (id: string) => void;
 }
 
-const LibraryList = React.memo(
+const LibraryList = 
     ({ libraries, librariesFilter, handleSelectLibrary }: LibraryListProps) => (
         
         <>
             {libraries.map((library, index) => (
-                <S.ListItem key={library.id}>
+                <S.ListItem key={`${library.id}-${index}`}>
                     <S.Checkbox
                         type="checkbox"
-                        id={`library-${index}`}
+                        id={`${library.id}-${index}`}
                         checked={librariesFilter.includes(library.id)}
                         onChange={() => handleSelectLibrary(library.id)}
                     />
-                    <S.Label htmlFor={`library-${index}`}>
+                    <S.Label htmlFor={`${library.id}-${index}`}>
                         {library.name}
                     </S.Label>
                 </S.ListItem>
             ))}
         </>
-    )
-);
+    );
 
 export default LibraryList

--- a/fe/src/components/Modal/LibrariesPaging/LibrariesPaging.tsx
+++ b/fe/src/components/Modal/LibrariesPaging/LibrariesPaging.tsx
@@ -3,7 +3,7 @@ import * as S from "@/styles/LibrariesPagingStyle";
 import { useEffect, useState } from "react";
 import { PAGINATION_FIRST_PAGE } from "@/constants";
 import { Pagination } from "antd";
-import { LIBRARIES_PER_PAGE } from "@/types/PageNation";
+import { LIBRARIES_PER_PAGE } from "@/constants";
 import useSearchFilter from "@/hooks/useFilterSearch";
 import { getCurrentPageItems } from "@/utils";
 interface LibrariesPagingProps {

--- a/fe/src/components/Modal/LibrariesPaging/LibrariesPaging.tsx
+++ b/fe/src/components/Modal/LibrariesPaging/LibrariesPaging.tsx
@@ -1,4 +1,4 @@
-import { LibrariesResponseType } from "@/types/LibrariesResponse";
+import { LibraryResponse } from "@/types/Books";
 import * as S from "@/styles/LibrariesPagingStyle";
 import { useEffect, useState } from "react";
 import { PAGINATION_FIRST_PAGE } from "@/constants";
@@ -7,18 +7,18 @@ import { LIBRARIES_PER_PAGE } from "@/constants";
 import useSearchFilter from "@/hooks/useFilterSearch";
 import { getCurrentPageItems } from "@/utils";
 interface LibrariesPagingProps {
-    libraryResponses: LibrariesResponseType[];
+    libraryResponses: LibraryResponse[];
 }
 
 const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
     const [currentPage, setCurrentPage] = useState(PAGINATION_FIRST_PAGE);
-    const { searchValue, setSearchValue, filteredLibraries } = useSearchFilter({
+    const { searchValue, setSearchValue, filteredLibraries } = useSearchFilter<LibraryResponse>({
         libraries: libraryResponses,
-        keyName: 'LibraryName'
+        keyName: 'libraryName'
     });
-
-    const currentPageLibraries = getCurrentPageItems(filteredLibraries, currentPage, LIBRARIES_PER_PAGE);
-
+    
+    const currentPageLibraries: LibraryResponse[] = getCurrentPageItems(filteredLibraries, currentPage, LIBRARIES_PER_PAGE);
+    
     const handlePageChange = (page: number) => setCurrentPage(page);
 
     useEffect(() => setCurrentPage(PAGINATION_FIRST_PAGE), [filteredLibraries]);
@@ -32,9 +32,9 @@ const LibrariesPaging = ({ libraryResponses }: LibrariesPagingProps) => {
                 onChange={(e) => setSearchValue(e.target.value)}
             />
             <S.LibrariesWrap>
-            {currentPageLibraries.map((curLibrary, idx) => (
-                    <S.LibraryItem key={idx} href={(curLibrary as LibrariesResponseType).BookLibraryUrl}>
-                        {(curLibrary as LibrariesResponseType).LibraryName}
+            {currentPageLibraries.map((curLibrary: LibraryResponse, idx) => (
+                    <S.LibraryItem key={idx} href={curLibrary.bookLibraryUrl}>
+                        {curLibrary.libraryName}
                     </S.LibraryItem>
                 ))}
             </S.LibrariesWrap>

--- a/fe/src/constants/index.ts
+++ b/fe/src/constants/index.ts
@@ -7,5 +7,6 @@ export const DROP_DOWN_INITIAL_ITEMS = [
 export const PAGINATION_FIRST_PAGE = 1
 export const FIRST_PAGE = 0;
 export const ANIMATION_TIME = 100;
-
+export const LIBRARIES_PER_PAGE = 5;
+export const LIBRARIES_FILTER_PER_PAGE = 20;
 export const DEBOUNCE_TIME = 300;

--- a/fe/src/hooks/useFilterSearch.tsx
+++ b/fe/src/hooks/useFilterSearch.tsx
@@ -1,20 +1,20 @@
 import { useMemo, useState } from "react";
 import useDebounce from "./useDebounce";
 import { DEBOUNCE_TIME } from "@/constants";
-import { LibrariesResponseType } from "@/types/LibrariesResponse";
+import { LibraryResponse } from "@/types/Books";
 import { LibrariesType } from "@/types/Libraries";
 
-type SearchableItem = LibrariesResponseType | LibrariesType;
+type SearchableItem = LibraryResponse | LibrariesType;
 
-interface UseSearchFilterProps {
-    libraries: SearchableItem[];
-    keyName: "name" | "LibraryName";
+interface UseSearchFilterProps<T extends SearchableItem> {
+    libraries: T[];
+    keyName: keyof T & string;
 }
 
-const useSearchFilter = ({ 
+const useSearchFilter = <T extends SearchableItem>({ 
     libraries, 
     keyName 
-}: UseSearchFilterProps) => {
+}: UseSearchFilterProps<T>) => {
     const [searchValue, setSearchValue] = useState("");
 
     const debouncedValue = useDebounce(searchValue, DEBOUNCE_TIME);
@@ -23,7 +23,7 @@ const useSearchFilter = ({
         if (!debouncedValue) return libraries;
 
         return libraries.filter((item) => {
-            const value = item[keyName as keyof SearchableItem];
+            const value = item[keyName];
             return typeof value === 'string' && value.toLowerCase().includes(debouncedValue.toLowerCase());
         });
     }, [debouncedValue, libraries, keyName]);

--- a/fe/src/hooks/useLibraryFilter.tsx
+++ b/fe/src/hooks/useLibraryFilter.tsx
@@ -15,7 +15,7 @@ export const useLibraryFilter = () => {
     const [disPlayLibraries, setDisplayLibraries] = useState<LibrariesType[]>([])
     const { librariesFilter, setLibrariesFilter, setPage } = useQueryStore();
     const { data = [], isLoading } = useQueryData("libraries");
-    const { searchValue, setSearchValue, filteredLibraries } = useSearchFilter({
+    const { searchValue, setSearchValue, filteredLibraries } = useSearchFilter<LibrariesType>({
         libraries: data,
         keyName: "name",
     });

--- a/fe/src/hooks/useLibraryFilter.tsx
+++ b/fe/src/hooks/useLibraryFilter.tsx
@@ -1,19 +1,32 @@
 import useQueryStore from "@/stores/queryStore";
-import { useState } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { FIRST_PAGE } from "@/constants";
 import useQueryData from "./useQueryData";
 import useSearchFilter from "./useFilterSearch";
+import { getCurrentPageItems } from "@/utils";
+import { LIBRARIES_FILTER_PER_PAGE, PAGINATION_FIRST_PAGE } from "@/constants";
+import useInfiniteScroll from "./useInfiniteScroll";
+import { LibrariesType } from "@/types/Libraries";
+
 export const useLibraryFilter = () => {
+    const observerRef = useRef(null);
     const [isOpen, setIsOpen] = useState(true);
+    const [filterPage, setFilterPage] = useState(PAGINATION_FIRST_PAGE);
+    const [disPlayLibraries, setDisplayLibraries] = useState<LibrariesType[]>([])
     const { librariesFilter, setLibrariesFilter, setPage } = useQueryStore();
-    const {data = [], isLoading} = useQueryData("libraries")
+    const { data = [], isLoading } = useQueryData("libraries");
     const { searchValue, setSearchValue, filteredLibraries } = useSearchFilter({
         libraries: data,
-        keyName: 'name'
+        keyName: "name",
     });
 
+    const getDisplayLibraries = useMemo(() => {
+        if (searchValue) return filteredLibraries;
+        return disPlayLibraries;
+    }, [searchValue, filteredLibraries, disPlayLibraries]);
+
     const handleSelectLibrary = (id: string) => {
-        setPage(FIRST_PAGE)
+        setPage(FIRST_PAGE);
         setLibrariesFilter(
             librariesFilter.includes(id)
                 ? librariesFilter.filter((item) => item !== id)
@@ -27,6 +40,23 @@ export const useLibraryFilter = () => {
         setSearchValue(e.target.value);
     };
 
+    const handleLoadMore = () => setFilterPage(prev => prev + 1);
+
+    const { observe } = useInfiniteScroll(handleLoadMore);
+
+    useEffect(() => {
+        if(data.length > 0) {
+        const newPageData: LibrariesType[] = getCurrentPageItems(data, filterPage, LIBRARIES_FILTER_PER_PAGE)
+        setDisplayLibraries(prevLibraries => [...prevLibraries, ...newPageData]) 
+        }   
+    }, [data, filterPage])
+
+    useEffect(() => {
+        if (observerRef.current) {
+            observe(observerRef.current);
+        }
+    }, [observe]);
+
     return {
         isOpen,
         searchValue,
@@ -35,6 +65,7 @@ export const useLibraryFilter = () => {
         toggleFilter,
         handleSearch,
         isLoading,
-        filteredLibraries
+        getDisplayLibraries,
+        observerRef,
     };
 };

--- a/fe/src/stories/Navigation.stories.tsx
+++ b/fe/src/stories/Navigation.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import Navigation from "@/components/Navigation/Navigation";
+import DefaultLayout from "@/components/Layout/DefaultLayout";
 
 const meta = {
-    title: "Components/Navigation",
-    component: Navigation,
+    title: "Components/DefaultLayout",
+    component: DefaultLayout,
     parameters: {
         layout: "center",
     },
-} as Meta<typeof Navigation>;
+} as Meta<typeof DefaultLayout>;
 
 export default meta;
 

--- a/fe/src/styles/BookCardStyle.ts
+++ b/fe/src/styles/BookCardStyle.ts
@@ -33,7 +33,8 @@ const ListCard = styled(Card)`
 `;
 
 const Image = styled.img`
-    object-fit: contain;
+    object-fit: cover;
+    width: 9rem;
     height: 13rem;
     border-radius: 0.375rem;
     margin: auto;

--- a/fe/src/styles/FilterDisplay.ts
+++ b/fe/src/styles/FilterDisplay.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 const FilterContainer = styled.div`
-    min-width: 240px;
+    width: 240px;
 
     @media (max-width: 768px) {
         margin: auto;

--- a/fe/src/styles/LibraryListStyle.ts
+++ b/fe/src/styles/LibraryListStyle.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 const ListItem = styled.li`
+    width: 100%;
     display: flex;
     align-items: center;
     margin-bottom: 0.5rem;
@@ -8,6 +9,7 @@ const ListItem = styled.li`
 
 const Checkbox = styled.input`
     margin-right: 0.5rem;
+    flex-shrink: 0;
     appearance: none;
     width: 1rem;
     height: 1rem;
@@ -26,6 +28,9 @@ const Checkbox = styled.input`
 const Label = styled.label`
     flex-grow: 1;
     font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 `;
 
 export { ListItem, Checkbox, Label };

--- a/fe/src/tests/componentsTests/LibrariesPaging.test.tsx
+++ b/fe/src/tests/componentsTests/LibrariesPaging.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import LibrariesPaging from "@/components/Modal/LibrariesPaging/LibrariesPaging";
-import { LibrariesResponseType } from "@/types/LibrariesResponse";
+import { LibraryResponse } from "@/types/Books";
 import { vi } from "vitest";
 
 vi.mock("@/styles/LibrariesPagingStyle", () => ({
@@ -11,11 +11,11 @@ vi.mock("@/styles/LibrariesPagingStyle", () => ({
     PagingWrap: "div",
 }));
 
-const mockLibraries: LibrariesResponseType[] = [
-    {id: "Id A", LibraryName: "Library A", BookLibraryUrl: "http://library-a.com" },
-    {id: "Id B", LibraryName: "Library B", BookLibraryUrl: "http://library-b.com" },
-    {id: "Id C", LibraryName: "Library C", BookLibraryUrl: "http://library-c.com" },
-    {id: "Id D", LibraryName: "Library D", BookLibraryUrl: "http://library-d.com" },
+const mockLibraries: LibraryResponse[] = [
+    {id: "Id A", libraryName: "Library A", bookLibraryUrl: "http://library-a.com" },
+    {id: "Id B", libraryName: "Library B", bookLibraryUrl: "http://library-b.com" },
+    {id: "Id C", libraryName: "Library C", bookLibraryUrl: "http://library-c.com" },
+    {id: "Id D", libraryName: "Library D", bookLibraryUrl: "http://library-d.com" },
 ];
 
 describe("LibrariesPaging 컴포넌트 테스트", () => {

--- a/fe/src/tests/componentsTests/LibraryFilter.test.tsx
+++ b/fe/src/tests/componentsTests/LibraryFilter.test.tsx
@@ -31,7 +31,8 @@ describe("LibraryFilter 컴포넌트 테스트", () => {
             toggleFilter: vi.fn(),
             handleSearch: vi.fn(),
             isLoading: false,
-            filteredLibraries: mockLibraries,
+            getDisplayLibraries: mockLibraries,
+            observerRef: { current: null },
         });
     });
 

--- a/fe/src/tests/hooksTests/useLibraryFilter.test.tsx
+++ b/fe/src/tests/hooksTests/useLibraryFilter.test.tsx
@@ -3,60 +3,51 @@ import { vi } from "vitest";
 import { useLibraryFilter } from "@/hooks/useLibraryFilter";
 
 const mockSetLibrariesFilter = vi.fn();
+const mockSetPage = vi.fn();
 
 vi.mock("@/stores/queryStore", () => ({
     __esModule: true,
     default: () => ({
         librariesFilter: [],
         setLibrariesFilter: mockSetLibrariesFilter,
-        setPage: mockSetLibrariesFilter,
+        setPage: mockSetPage,
     }),
 }));
 
-interface QueryData {
-    data: Array<{ id: string; name: string }>;
-    isLoading: boolean;
-}
+const mockLibraries = [
+    { id: "1", name: "Library 1" },
+    { id: "2", name: "Library 2" },
+    { id: "3", name: "Library 3" },
+];
 
 vi.mock('@/hooks/useQueryData', () => ({
-    default: (key: string): QueryData => {
-        if (key === "libraries") {
-            return {
-                data: [
-                    { id: "1", name: "Library 1" },
-                    { id: "2", name: "Library 2" },
-                ],
-                isLoading: false,
-            };
-        }
-        return { data: [], isLoading: true };
-    },
+    default: () => ({
+        data: mockLibraries,
+        isLoading: false,
+    }),
 }));
 
-global.fetch = vi.fn(() =>
-    Promise.resolve({
-        json: () =>
-            Promise.resolve([
-                { id: "1", name: "Library 1" },
-                { id: "2", name: "Library 2" },
-            ]),
-    })
-) as unknown as typeof fetch;
+vi.mock('@/hooks/useInfiniteScroll', () => ({
+    default: () => ({
+        observe: vi.fn(),
+    }),
+}));
 
 describe("useLibraryFilter 테스트", () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
-    test("useLibraryFilter이 초기 value값을 갖고 있는지 확인.", () => {
+    test("초기 상태 확인", () => {
         const { result } = renderHook(() => useLibraryFilter());
 
         expect(result.current.searchValue).toBe("");
         expect(result.current.isOpen).toBe(true);
         expect(result.current.librariesFilter).toEqual([]);
+        expect(result.current.isLoading).toBe(false);
     });
 
-    test("토글버튼을 클릭했을때 state가 변경되는지 확인.", () => {
+    test("toggleFilter 기능 확인", () => {
         const { result } = renderHook(() => useLibraryFilter());
 
         act(() => {
@@ -70,42 +61,23 @@ describe("useLibraryFilter 테스트", () => {
         expect(result.current.isOpen).toBe(true);
     });
 
-    test("검색을 했을때 search state가 value로 변경되는지 확인.", () => {
+    test("handleSearch 기능 확인", () => {
         const { result } = renderHook(() => useLibraryFilter());
 
         act(() => {
             result.current.handleSearch({
-                target: { value: "search query" },
+                target: { value: "Library 1" },
             } as React.ChangeEvent<HTMLInputElement>);
         });
 
-        expect(result.current.searchValue).toBe("search query");
-    });
-
-    test("handleSelectLibrary가 올바르게 librariesFilter를 추가/제거 하는지 확인.", () => {
-        const { result } = renderHook(() => useLibraryFilter());
-
-        expect(result.current.librariesFilter).toEqual([]);
+        expect(result.current.searchValue).toBe("Library 1");
 
         act(() => {
-            result.current.handleSelectLibrary("1");
+            result.current.handleSearch({
+                target: { value: "" },
+            } as React.ChangeEvent<HTMLInputElement>);
         });
-        expect(mockSetLibrariesFilter).toHaveBeenCalledWith(["1"]);
-        result.current.librariesFilter.push("1")
-        expect(result.current.librariesFilter).toEqual(["1"]);
 
-        act(() => {
-            result.current.handleSelectLibrary("2");
-        });
-        expect(mockSetLibrariesFilter).toHaveBeenCalledWith(["1", "2"]);
-        result.current.librariesFilter.push("2")
-        expect(result.current.librariesFilter).toEqual(["1", "2"]);
-
-        act(() => {
-            result.current.handleSelectLibrary("1");
-        });
-        expect(mockSetLibrariesFilter).toHaveBeenCalledWith(["2"]);
-        result.current.librariesFilter = ["2"];
-        expect(result.current.librariesFilter).toEqual(["2"]);
+        expect(result.current.searchValue).toBe("");
     });
 });

--- a/fe/src/tests/pagesTests/Layout.test.tsx
+++ b/fe/src/tests/pagesTests/Layout.test.tsx
@@ -2,8 +2,17 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import DefaultLayout from "@/components/Layout/DefaultLayout";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
 
 const queryClient = new QueryClient();
+
+const mockIntersectionObserver = vi.fn();
+mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    unobserve: () => null,
+    disconnect: () => null,
+});
+window.IntersectionObserver = mockIntersectionObserver;
 
 test("Navigation이 렌더링 되었을때 Outlet이 렌더링 되는지 확인", () => {
     render(

--- a/fe/src/types/Books.ts
+++ b/fe/src/types/Books.ts
@@ -1,7 +1,7 @@
 export interface LibraryResponse {
     id: string;
-    LibraryName: string;
-    BookLibraryUrl: string;
+    libraryName: string;
+    bookLibraryUrl: string;
 }
 export interface BookContent {
     id: string;

--- a/fe/src/types/LibrariesResponse.ts
+++ b/fe/src/types/LibrariesResponse.ts
@@ -1,5 +1,0 @@
-export interface LibrariesResponseType {
-    id: string;
-    LibraryName: string;
-    BookLibraryUrl: string;
-}

--- a/fe/src/types/PageNation.ts
+++ b/fe/src/types/PageNation.ts
@@ -1,1 +1,0 @@
-export const LIBRARIES_PER_PAGE = 5;

--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -4,6 +4,17 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://api.meetyourbook.site',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+        secure: false,
+        ws: true
+      }
+    }
+  },
   resolve: {
     alias: [
       { find: '@', replacement: path.resolve(__dirname, 'src') },


### PR DESCRIPTION
## 변경 사항
- api proxy 우회 설정
- 필터 도서관 이름이 박스를 넘칠때 ...으로 표시 하도록 수정
- 이미지 width 수정
- 페이지 첫 진입시 5000개의 도서관 정보를 불러와 한번에 그리지 않고 나눠서 그리도록 개선
- 5000개의 데이터를 20개씩 잘라 렌더링해 렌더링 과부화 개선
- useInfiniteScroll을 적용해 스크롤 시 최 하단을 감지해 20개씩 데이터 추가
- 프로토콜을 명시적으로 지정하지 않고 현재 페이지의 상대 프로토콜을 자동으로 사용하도록 수정
- //: 로 시작하면 http 환경에서는 http로 요청하고  https 환경에서는 https 요청함
- librariesResponse 타입 에러 수정
- 중복 선언된 타입 제거
- 로직 변경에 따른 테스트코드 및 스토리북 수정

## 변경 유형
해당하는 항목에 x 표시를 해주세요:
- [ ] 버그 수정
- [X] 새로운 기능
- [ ] 코드 스타일 변경 (포맷팅, 변수명 등)
- [X] 리팩토링
- [ ] 문서 내용 변경
- [X] 테스트 코드 추가
- [ ] 기타 (설명해 주세요)
